### PR TITLE
Add configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Configuration files
+appsettings*.json

--- a/DCCollectionsRequest/appsettings.json
+++ b/DCCollectionsRequest/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=CollectionsDb;User Id=username;Password=password;"
+  },
+  "SqlQueries": {
+    "Collections": "SELECT * FROM Collections WHERE Processed = 0;",
+    "CreditorDefaults": "SELECT * FROM CreditorDefaults WHERE CreditorId = @CreditorId;"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@
    dotnet build
    ```
 
+## Configuration
+
+Create an `appsettings.json` file inside the `DCCollectionsRequest` directory. It should provide the database connection and SQL queries used by the application. Example:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=CollectionsDb;User Id=username;Password=password;"
+  },
+  "SqlQueries": {
+    "Collections": "SELECT * FROM Collections WHERE Processed = 0;",
+    "CreditorDefaults": "SELECT * FROM CreditorDefaults WHERE CreditorId = @CreditorId;"
+  }
+}
+```
+
 ## Running
 
 The executable expects a fixed width file named `RM-Collections.txt` in the `DCCollectionsRequest` directory. The sample file is included and is copied to the output folder during the build.


### PR DESCRIPTION
## Summary
- provide sample `appsettings.json`
- ignore local `appsettings` files
- document configuration in README

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`


------
https://chatgpt.com/codex/tasks/task_b_684a90f3648c832880cc6a05aafb5892