### PR TITLE
Move SQL queries to external files

### DIFF
--- a/DCCollectionsRequest/DCCollectionsRequest.csproj
+++ b/DCCollectionsRequest/DCCollectionsRequest.csproj
@@ -17,6 +17,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="SqlQueries\*.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="ZR07675.AUL.DATA.250529.122006">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
+using System.IO;
 
 public class CreditorDefaults
 {
@@ -32,10 +33,10 @@ public class DatabaseService
 
         _connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? throw new InvalidOperationException("DefaultConnection missing");
-        _collectionsSql = configuration["SqlQueries:Collections"]
-            ?? throw new InvalidOperationException("Collections SQL missing");
-        _creditorDefaultsSql = configuration["SqlQueries:CreditorDefaults"]
-            ?? throw new InvalidOperationException("CreditorDefaults SQL missing");
+
+        var queriesPath = configuration["SqlQueriesPath"] ?? "SqlQueries";
+        _collectionsSql = File.ReadAllText(Path.Combine(queriesPath, "Collections.sql"));
+        _creditorDefaultsSql = File.ReadAllText(Path.Combine(queriesPath, "CreditorDefaults.sql"));
     }
 
     public async Task<List<DebtorCollectionData>> GetCollectionsAsync()

--- a/DCCollectionsRequest/SqlQueries/Collections.sql
+++ b/DCCollectionsRequest/SqlQueries/Collections.sql
@@ -1,0 +1,26 @@
+SELECT mmb.MANDATEUSERREF AS PaymentInformation,
+       CONVERT(char(10), DATEFROMPARTS(YEAR(base_month), MONTH(base_month),
+              CASE WHEN DEDUCTIONDAY > DAY(EOMONTH(base_month))
+                   THEN DAY(EOMONTH(base_month)) ELSE DEDUCTIONDAY END), 23) AS RequestedCollectionDate,
+       DEDUCTIONDAY,
+       GETDATE() AS TrackingPeriod,
+       'RCUR' AS DebitSequence,
+       '0021' AS EntryClass,
+       1501 AS InstructedAmount,
+       mmb.AUTHORISATIONREF AS MandateReference,
+       mmb.BRANCHCODE AS DebtorBankBranch,
+       mm.FIRSTNM,
+       mm.LASTNM AS DebtorName,
+       mmb.ACCNR AS DebtorAccountNumber,
+       mmb.ACCTYPE AS AccountType,
+       mmb.MANDATEUSERREF AS ContractReference,
+       GETDATE() AS RelatedCycleDate
+FROM (
+    SELECT *,
+           DATEADD(month,
+                   CASE WHEN DAY(GETDATE()) <= DEDUCTIONDAY THEN 0 ELSE 1 END,
+                   DATEFROMPARTS(YEAR(GETDATE()), MONTH(GETDATE()), 1)) AS base_month
+    FROM MEMBMANDATE_BANKHIST
+) AS mmb
+INNER JOIN MEMB_MASTERS AS mm ON mmb.MEMBID = mm.MEMBID
+WHERE DEDUCTIONDAY = @DEDUCTIONDAY;

--- a/DCCollectionsRequest/SqlQueries/CreditorDefaults.sql
+++ b/DCCollectionsRequest/SqlQueries/CreditorDefaults.sql
@@ -1,0 +1,1 @@
+SELECT * FROM CreditorDefaults WHERE CreditorId = @CreditorId;

--- a/README.md
+++ b/README.md
@@ -16,19 +16,18 @@
 
 ## Configuration
 
-Create an `appsettings.json` file inside the `DCCollectionsRequest` directory. It should provide the database connection and SQL queries used by the application. Example:
+Create an `appsettings.json` file inside the `DCCollectionsRequest` directory. It should provide the database connection and the path to the SQL query files used by the application. Example:
 
 ```json
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=CollectionsDb;User Id=username;Password=password;"
   },
-  "SqlQueries": {
-    "Collections": "SELECT * FROM Collections WHERE Processed = 0;",
-    "CreditorDefaults": "SELECT * FROM CreditorDefaults WHERE CreditorId = @CreditorId;"
-  }
+  "SqlQueriesPath": "SqlQueries"
 }
 ```
+
+Create a folder named `SqlQueries` next to `appsettings.json` and place the queries inside `Collections.sql` and `CreditorDefaults.sql`. These files support normal line breaks for readability.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- store SQL query text in `SqlQueries/*.sql` files
- copy new SQL files on build
- read SQL queries from files at runtime
- document new configuration values for query directory

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ae16b6a4083288ed84b7047dc2c03