### PR TITLE
Persist folder paths and add CSV viewer

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -43,6 +43,7 @@
         private System.Windows.Forms.TextBox txtRaw;
         private System.Windows.Forms.TextBox txtReference;
         private System.Windows.Forms.Button btnLookup;
+        private System.Windows.Forms.Button btnOpenCsv;
 
         private void InitializeComponent()
         {
@@ -63,6 +64,7 @@
             txtFolder = new TextBox();
             txtReference = new TextBox();
             btnLookup = new Button();
+            btnOpenCsv = new Button();
             tabMain.SuspendLayout();
             tabOperations.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudDay).BeginInit();
@@ -175,6 +177,7 @@
             tabParse.Controls.Add(txtFolder);
             tabParse.Controls.Add(txtReference);
             tabParse.Controls.Add(btnLookup);
+            tabParse.Controls.Add(btnOpenCsv);
             tabParse.Location = new Point(4, 24);
             tabParse.Name = "tabParse";
             tabParse.Padding = new Padding(3, 3, 3, 3);
@@ -247,9 +250,19 @@
             btnLookup.Text = "Lookup Ref";
             btnLookup.UseVisualStyleBackColor = true;
             btnLookup.Click += btnLookup_Click;
-            // 
+            //
+            // btnOpenCsv
+            //
+            btnOpenCsv.Location = new Point(132, 263);
+            btnOpenCsv.Name = "btnOpenCsv";
+            btnOpenCsv.Size = new Size(120, 23);
+            btnOpenCsv.TabIndex = 9;
+            btnOpenCsv.Text = "Open CSV";
+            btnOpenCsv.UseVisualStyleBackColor = true;
+            btnOpenCsv.Click += btnOpenCsv_Click;
+            //
             // MainForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1189, 637);

--- a/DCCollections.Gui/UserSettings.cs
+++ b/DCCollections.Gui/UserSettings.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace DCCollections.Gui
+{
+    public class UserSettings
+    {
+        public string? OperationFolderPath { get; set; }
+        public string? ParseFolderPath { get; set; }
+
+        private static string SettingsFile => Path.Combine(AppContext.BaseDirectory, "usersettings.json");
+
+        public static UserSettings Load()
+        {
+            try
+            {
+                if (File.Exists(SettingsFile))
+                {
+                    var json = File.ReadAllText(SettingsFile);
+                    var settings = JsonSerializer.Deserialize<UserSettings>(json);
+                    if (settings != null)
+                        return settings;
+                }
+            }
+            catch { }
+            return new UserSettings();
+        }
+
+        public void Save()
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(SettingsFile, json);
+            }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve last selected folders in a new `usersettings.json`
- load saved folders on start to repopulate UI
- display file details in both list boxes
- start main form maximised
- add button to open the CSV store

## Testing
- `dotnet build DCCollections.Gui/DCCollections.Gui.csproj`

------
https://chatgpt.com/codex/tasks/task_b_6853e06141b08328984314e2dac91441