### PR TITLE
Add billing collection requests insertion

### DIFF
--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -156,8 +156,13 @@ namespace RMCollectionProcessor
                 typeof(TransmissionTrailer999));
 
             engine.WriteFile(fileName, records);
+
             if (!isTest)
             {
+                // Parse the generated file and store each request
+                var txRecords = ExtractTransactionRecords(fileName, records.ToArray());
+                dbService.InsertCollectionRequests(txRecords, fileRowId);
+
                 dbService.MarkBankFileGenerationComplete(fileRowId);
             }
 


### PR DESCRIPTION
## Summary
- add `InsertCollectionRequests` helper to `DatabaseService`
- store collection request info whenever a live file is generated

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj -v:m`

------
https://chatgpt.com/codex/tasks/task_b_6853f1f7ac6483288d1007446104aa87