### PR TITLE
Display DB connection string on startup

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -30,11 +30,32 @@ namespace DCCollections.Gui
                 .SetBasePath(AppContext.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: true)
                 .Build();
+
+            // Display the connection string (without the password) to the user
+            var connStr = _config.GetConnectionString("DefaultConnection");
+            if (!string.IsNullOrWhiteSpace(connStr))
+            {
+                var safeConn = RemovePassword(connStr);
+                MessageBox.Show(safeConn, "Database Connection");
+                Text = $"Collections - {safeConn}";
+            }
+
             _service = new RMCollectionProcessor.CollectionService();
             _settings = UserSettings.Load();
             WindowState = FormWindowState.Maximized;
             MaximizeBox = true;
             LoadInitialPaths();
+        }
+
+        private static string RemovePassword(string connection)
+        {
+            var builder = new System.Data.Common.DbConnectionStringBuilder
+            {
+                ConnectionString = connection
+            };
+            builder.Remove("Password");
+            builder.Remove("Pwd");
+            return builder.ConnectionString;
         }
 
         private void btnParse_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- show database connection string on startup without the password
- use the sanitized connection string in the main window caption

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj`
- `dotnet build DCCollections.Gui/DCCollections.Gui.csproj`


------
https://chatgpt.com/codex/tasks/task_b_6853f39bc3648328809120ff919ac64d