### PR TITLE
Update import tab to parse files

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -9,6 +9,7 @@ namespace DCCollections.Gui
         private readonly RMCollectionProcessor.CollectionService _service;
         private readonly Microsoft.Extensions.Configuration.IConfiguration _config;
         private object[]? _parsedRecords;
+        private RMCollectionProcessor.FileType _currentFileType;
         private readonly UserSettings _settings;
 
         private class FileListItem
@@ -65,8 +66,10 @@ namespace DCCollections.Gui
             {
                 try
                 {
-                    _parsedRecords = _service.ParseFile(ofd.FileName);
-                    MessageBox.Show($"Parsed {_parsedRecords.Length} records.", "Success");
+                    var result = _service.ParseFile(ofd.FileName);
+                    _parsedRecords = result.Records;
+                    _currentFileType = result.FileType;
+                    MessageBox.Show($"Parsed {_parsedRecords.Length} records (Type: {_currentFileType}).", "Success");
                 }
                 catch (Exception ex)
                 {
@@ -143,9 +146,11 @@ namespace DCCollections.Gui
             {
                 try
                 {
-                    _parsedRecords = _service.ParseFile(item.Path);
+                    var result = _service.ParseFile(item.Path);
+                    _parsedRecords = result.Records;
+                    _currentFileType = result.FileType;
                     txtRaw.Text = File.ReadAllText(item.Path);
-                    MessageBox.Show($"Parsed {_parsedRecords.Length} records.", "Success");
+                    MessageBox.Show($"Parsed {_parsedRecords.Length} records (Type: {_currentFileType}).", "Success");
                 }
                 catch (Exception ex)
                 {
@@ -280,6 +285,24 @@ namespace DCCollections.Gui
         private void lvImportFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
             btnImportRead.Enabled = lvImportFiles.SelectedItems.Count > 0;
+
+            if (lvImportFiles.SelectedItems.Count > 0)
+            {
+                var path = lvImportFiles.SelectedItems[0].Tag as string;
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    try
+                    {
+                        var result = _service.ParseFile(path);
+                        _parsedRecords = result.Records;
+                        _currentFileType = result.FileType;
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(ex.Message, "Error");
+                    }
+                }
+            }
         }
 
         private void btnImportRead_Click(object sender, EventArgs e)

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -22,8 +22,8 @@ namespace RMCollectionProcessor
         /// Parses the specified file, identifies its type, and routes it to the appropriate processing logic.
         /// </summary>
         /// <param name="filePath">The path to the file to parse.</param>
-        /// <returns>An array of the parsed record objects from the file.</returns>
-        public object[] ParseFile(string filePath)
+        /// <returns>The parsed records and their detected file type.</returns>
+        public ParseResult ParseFile(string filePath)
         {
             if (!File.Exists(filePath))
                 throw new FileNotFoundException($"File '{filePath}' not found.");
@@ -48,7 +48,7 @@ namespace RMCollectionProcessor
                     throw new InvalidDataException($"The file '{filePath}' is of an unknown or unsupported type.");
             }
 
-            return parsed;
+            return new ParseResult(parsed, fileType);
         }
 
         public string GenerateFile(int deductionDay, IConfiguration configuration, bool isTest = false)

--- a/DCCollectionsRequest/ParseResult.cs
+++ b/DCCollectionsRequest/ParseResult.cs
@@ -1,0 +1,7 @@
+namespace RMCollectionProcessor
+{
+    /// <summary>
+    /// Represents the outcome of parsing a file.
+    /// </summary>
+    public record ParseResult(object[] Records, FileType FileType);
+}


### PR DESCRIPTION
## Summary
- parse on import file selection
- return file type with parsed records

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.csproj`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj --no-restore`
- `dotnet restore DCCollections.Gui/DCCollections.Gui.csproj`
- `dotnet build DCCollections.Gui/DCCollections.Gui.csproj --no-restore`


------
https://chatgpt.com/codex/tasks/task_b_6855602575588328b70855b55aefd12c