### PR TITLE
Add import support for StatusReport

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -44,6 +44,7 @@
         private System.Windows.Forms.TextBox txtImportFolder;
         private System.Windows.Forms.Button btnImportBrowse;
         private System.Windows.Forms.Button btnImportRead;
+        private System.Windows.Forms.Button btnImportParse;
         private System.Windows.Forms.ListView lvImportFiles;
         private System.Windows.Forms.ColumnHeader chName;
         private System.Windows.Forms.ColumnHeader chSize;
@@ -70,6 +71,7 @@
             txtImportFolder = new TextBox();
             btnImportBrowse = new Button();
             btnImportRead = new Button();
+            btnImportParse = new Button();
             lvImportFiles = new ListView();
             chName = new ColumnHeader();
             chSize = new ColumnHeader();
@@ -244,6 +246,7 @@
             //
             // pnlImportTop
             //
+            pnlImportTop.Controls.Add(btnImportParse);
             pnlImportTop.Controls.Add(btnImportRead);
             pnlImportTop.Controls.Add(btnImportBrowse);
             pnlImportTop.Controls.Add(txtImportFolder);
@@ -283,6 +286,18 @@
             btnImportRead.Text = "Read File";
             btnImportRead.UseVisualStyleBackColor = true;
             btnImportRead.Click += btnImportRead_Click;
+
+            //
+            // btnImportParse
+            //
+            btnImportParse.Enabled = false;
+            btnImportParse.Location = new Point(461, 4);
+            btnImportParse.Name = "btnImportParse";
+            btnImportParse.Size = new Size(100, 23);
+            btnImportParse.TabIndex = 3;
+            btnImportParse.Text = "Import";
+            btnImportParse.UseVisualStyleBackColor = true;
+            btnImportParse.Click += btnImportParse_Click;
 
             //
             // lvImportFiles

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -284,24 +284,30 @@ namespace DCCollections.Gui
 
         private void lvImportFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            btnImportRead.Enabled = lvImportFiles.SelectedItems.Count > 0;
+            bool hasSelection = lvImportFiles.SelectedItems.Count > 0;
+            btnImportRead.Enabled = hasSelection;
+            btnImportParse.Enabled = hasSelection;
+        }
 
-            if (lvImportFiles.SelectedItems.Count > 0)
+        private void btnImportParse_Click(object sender, EventArgs e)
+        {
+            if (lvImportFiles.SelectedItems.Count == 0)
+                return;
+
+            var path = lvImportFiles.SelectedItems[0].Tag as string;
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            try
             {
-                var path = lvImportFiles.SelectedItems[0].Tag as string;
-                if (!string.IsNullOrWhiteSpace(path))
-                {
-                    try
-                    {
-                        var result = _service.ParseFile(path, _config);
-                        _parsedRecords = result.Records;
-                        _currentFileType = result.FileType;
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show(ex.Message, "Error");
-                    }
-                }
+                var result = _service.ParseFile(path, _config);
+                _parsedRecords = result.Records;
+                _currentFileType = result.FileType;
+                MessageBox.Show($"Imported {_parsedRecords.Length} records (Type: {_currentFileType}).", "Success");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
             }
         }
 


### PR DESCRIPTION
## Summary
- update WinForms UI to import files manually via `Import` button
- add `btnImportParse_Click` handler to parse and import selected files

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`

------
https://chatgpt.com/codex/tasks/task_b_68595d35521c8328bfe0df0159298fc3