### PR TITLE
Refactor file type models

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -1,15 +1,16 @@
 using Microsoft.Extensions.Configuration;
 using System.Diagnostics;
 using System.IO;
+using RMCollectionProcessor.Models;
 
 namespace DCCollections.Gui
 {
     public partial class MainForm : Form
     {
         private readonly RMCollectionProcessor.CollectionService _service;
-        private readonly Microsoft.Extensions.Configuration.IConfiguration _config;
+        private readonly IConfiguration _config;
         private object[]? _parsedRecords;
-        private RMCollectionProcessor.FileType _currentFileType;
+        private FileType _currentFileType;
         private readonly UserSettings _settings;
 
         private class FileListItem

--- a/DCCollections.Models/DCCollections.Models.csproj
+++ b/DCCollections.Models/DCCollections.Models.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DCCollections.Models/FileTypeIdentifier.cs
+++ b/DCCollections.Models/FileTypeIdentifier.cs
@@ -1,6 +1,6 @@
-﻿using RMCollectionProcessor.Models;
+using RMCollectionProcessor.Models;
 
-namespace RMCollectionProcessor
+namespace RMCollectionProcessor.Models
 {
     /// <summary>
     /// Defines the types of RM files that can be processed.

--- a/DCCollections.Models/ParseResult.cs
+++ b/DCCollections.Models/ParseResult.cs
@@ -1,4 +1,4 @@
-namespace RMCollectionProcessor
+namespace RMCollectionProcessor.Models
 {
     /// <summary>
     /// Represents the outcome of parsing a file.

--- a/DCCollections.Models/StatusReportTransaction.cs
+++ b/DCCollections.Models/StatusReportTransaction.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 
-namespace RMCollectionProcessor
+namespace RMCollectionProcessor.Models
 {
     /// <summary>
     /// Represents a single, consolidated transaction from a Status Report file.

--- a/DCCollections.Models/TransactionRecord.cs
+++ b/DCCollections.Models/TransactionRecord.cs
@@ -1,4 +1,4 @@
-namespace RMCollectionProcessor
+namespace RMCollectionProcessor.Models
 {
     public class TransactionRecord
     {

--- a/DCCollectionsRequest/CsvFileStore.cs
+++ b/DCCollectionsRequest/CsvFileStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using RMCollectionProcessor.Models;
 
 namespace RMCollectionProcessor
 {


### PR DESCRIPTION
## Summary
- move FileTypeIdentifier and FileType enum into models project
- move ParseResult and transaction models into models
- update GUI and CSV store to use new namespaces
- target net8.0 for models project

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_b_68597fac010883288b3d326396e65a42