### PR TITLE
Set default to Test on Operations tab

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -46,6 +46,7 @@ namespace DCCollections.Gui
             _settings = UserSettings.Load();
             WindowState = FormWindowState.Maximized;
             MaximizeBox = true;
+            chkTest.Checked = true;
             LoadInitialPaths();
         }
 


### PR DESCRIPTION
## Summary
- default `chkTest` to checked so test mode is used when opening the Operations tab

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_b_685a43373cf08328a0a3a15cb8507863