### PR TITLE
Create centralized DB connection layer

### DIFF
--- a/DCCollections.Gui/DCCollections.Gui.csproj
+++ b/DCCollections.Gui/DCCollections.Gui.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DCCollections.Models\DC-Models-Identifier.csproj" />
     <ProjectReference Include="..\DCCollectionsRequest\CollectionsRequest.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <ProjectReference Include="..\DbConnection\DbConnection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -1,5 +1,4 @@
 using FileHelpers;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -24,7 +23,7 @@ namespace RMCollectionProcessor
         /// </summary>
         /// <param name="filePath">The path to the file to parse.</param>
         /// <returns>The parsed records and their detected file type.</returns>
-        public ParseResult ParseFile(string filePath, IConfiguration configuration)
+        public ParseResult ParseFile(string filePath)
         {
             if (!File.Exists(filePath))
                 throw new FileNotFoundException($"File '{filePath}' not found.");
@@ -33,7 +32,7 @@ namespace RMCollectionProcessor
             var parsed = processor.ProcessFile(filePath);
 
             var fileType = FileTypeIdentifier.Identify(parsed);
-            var dbService = new DatabaseService(configuration);
+            var dbService = new DatabaseService();
             switch (fileType)
             {
                 case FileType.CollectionRequest:
@@ -125,12 +124,12 @@ namespace RMCollectionProcessor
         }
 
 
-        public string GenerateFile(int deductionDay, IConfiguration configuration, bool isTest = false, string? outputFolder = null)
+        public string GenerateFile(int deductionDay, bool isTest = false, string? outputFolder = null)
         {
             if (deductionDay < 1 || deductionDay > 31)
                 throw new ArgumentOutOfRangeException(nameof(deductionDay), "Deduction day must be between 1 and 31.");
 
-            var dbService = new DatabaseService(configuration);
+            var dbService = new DatabaseService();
 
             var collections = dbService.GetCollections(deductionDay);
             if (!collections.Any())
@@ -264,15 +263,15 @@ namespace RMCollectionProcessor
             return fullPath;
         }
 
-        public BillingCollectionRequest? GetRequestByReference(string reference, IConfiguration configuration)
+        public BillingCollectionRequest? GetRequestByReference(string reference)
         {
-            var dbService = new DatabaseService(configuration);
+            var dbService = new DatabaseService();
             return dbService.GetCollectionRequestByReference(reference);
         }
 
-        public DataTable GetDuplicateCollections(int deductionDay, IConfiguration configuration)
+        public DataTable GetDuplicateCollections(int deductionDay)
         {
-            var dbService = new DatabaseService(configuration);
+            var dbService = new DatabaseService();
             return dbService.GetDuplicateCollections(deductionDay);
         }
 

--- a/DCCollectionsRequest/CollectionsRequest.csproj
+++ b/DCCollectionsRequest/CollectionsRequest.csproj
@@ -9,17 +9,14 @@
   <ItemGroup>
     <PackageReference Include="FileHelpers" Version="3.5.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\DCCollections.Models\DC-Models-Identifier.csproj" />
+    <ProjectReference Include="..\DbConnection\DbConnection.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="SqlQueries\*.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/DCCollectionsRequest/DCCollectionsRequest.sln
+++ b/DCCollectionsRequest/DCCollectionsRequest.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DCCollections.Gui", "..\DCC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DC-Models-Identifier", "..\DCCollections.Models\DC-Models-Identifier.csproj", "{CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbConnection", "..\DbConnection\DbConnection.csproj", "{4499FF50-7C80-4F43-8768-A400FC757866}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,11 +24,15 @@ Global
 		{A1F6CD65-5B82-4D39-9D9D-6335CB39E2CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A1F6CD65-5B82-4D39-9D9D-6335CB39E2CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1F6CD65-5B82-4D39-9D9D-6335CB39E2CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CE7DB63F-ED4D-4C9A-9CE9-5F3A62DFA22B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4499FF50-7C80-4F43-8768-A400FC757866}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4499FF50-7C80-4F43-8768-A400FC757866}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4499FF50-7C80-4F43-8768-A400FC757866}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4499FF50-7C80-4F43-8768-A400FC757866}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.SqlClient;
-using Microsoft.Extensions.Configuration;
+using DbConnection;
 using System.IO;
 using System.Linq;
 using RMCollectionProcessor.Models;
@@ -16,13 +16,10 @@ public class DatabaseService
     private readonly string _collectionsSql;
     private readonly string _creditorDefaultsSql;
 
-    public DatabaseService(IConfiguration configuration)
+    public DatabaseService()
     {
-        if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-
-        _connectionString = configuration.GetConnectionString("DefaultConnection")
-            ?? throw new InvalidOperationException("DefaultConnection missing");
-
+        var configuration = AppConfig.Configuration;
+        _connectionString = AppConfig.ConnectionString;
         var queriesPath = configuration["SqlQueriesPath"] ?? "SqlQueries";
         _collectionsSql = File.ReadAllText(Path.Combine(queriesPath, "Collections.sql"));
         _creditorDefaultsSql = File.ReadAllText(Path.Combine(queriesPath, "CreditorDefaults.sql"));

--- a/DbConnection/AppConfig.cs
+++ b/DbConnection/AppConfig.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace DbConnection
+{
+    public static class AppConfig
+    {
+        private static IConfiguration? _config;
+
+        public static IConfiguration Configuration
+        {
+            get
+            {
+                if (_config == null)
+                {
+                    _config = new ConfigurationBuilder()
+                        .SetBasePath(AppContext.BaseDirectory)
+                        .AddJsonFile("appsettings.json", optional: true)
+                        .Build();
+                }
+                return _config;
+            }
+        }
+
+        public static string ConnectionString =>
+            Configuration.GetConnectionString("DefaultConnection") ??
+            throw new InvalidOperationException("DefaultConnection missing");
+    }
+}

--- a/DbConnection/DbConnection.csproj
+++ b/DbConnection/DbConnection.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/DbConnection/appsettings.json.sample
+++ b/DbConnection/appsettings.json.sample
@@ -1,0 +1,6 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=CollectionsDb;User Id=username;Password=password;"
+  },
+  "SqlQueriesPath": "SqlQueries"
+}

--- a/EFT-Collections/DatabaseService.cs
+++ b/EFT-Collections/DatabaseService.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Data.SqlClient;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
+using DbConnection;
 
 namespace EFT_Collections;
 
@@ -15,13 +15,10 @@ public class DatabaseService
     private readonly string _collectionsSql;
     private readonly string _creditorDefaultsSql;
 
-    public DatabaseService(IConfiguration configuration)
+    public DatabaseService()
     {
-        if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-
-        _connectionString = configuration.GetConnectionString("DefaultConnection")
-            ?? throw new InvalidOperationException("DefaultConnection missing");
-
+        var configuration = AppConfig.Configuration;
+        _connectionString = AppConfig.ConnectionString;
         var queriesPath = configuration["SqlQueriesPath"] ?? "SqlQueries";
         _collectionsSql = File.ReadAllText(Path.Combine(queriesPath, "Collections.sql"));
         _creditorDefaultsSql = File.ReadAllText(Path.Combine(queriesPath, "CreditorDefaults.sql"));

--- a/EFT-Collections/EFT-Collections.csproj
+++ b/EFT-Collections/EFT-Collections.csproj
@@ -13,16 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DbConnection\DbConnection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FileHelpers" Version="3.5.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="SqlQueries\Collections - Copy %282%29.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/EFT-Collections/Program.cs
+++ b/EFT-Collections/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using EFT_Collections;
-using Microsoft.Extensions.Configuration;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -90,10 +89,7 @@ public class Program
             recordStatus: dataSetStatus
         );
 
-        var configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json", optional: true)
-            .Build();
-        var db = new DatabaseService(configuration);
+        var db = new DatabaseService();
 
 
         int generationNumber;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Configuration
 
-Create an `appsettings.json` file inside the `DCCollectionsRequest` directory. It should provide the database connection and the path to the SQL query files used by the application. Example:
+Create an `appsettings.json` file inside the `DbConnection` directory. It provides the database connection and the path to the SQL query files used by the applications. Example:
 
 ```json
 {
@@ -27,7 +27,7 @@ Create an `appsettings.json` file inside the `DCCollectionsRequest` directory. I
 }
 ```
 
-Create a folder named `SqlQueries` next to `appsettings.json` and place the queries inside `Collections.sql` and `CreditorDefaults.sql`. These files support normal line breaks for readability.
+Create a folder named `SqlQueries` next to `appsettings.json` in the `DbConnection` directory and place the queries inside `Collections.sql` and `CreditorDefaults.sql`. These files support normal line breaks for readability.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add new `DbConnection` project targeting `netstandard2.0`
- centralize reading `appsettings.json` in `AppConfig`
- remove direct connection-string handling from other projects
- reference the new library from GUI, request and EFT projects
- update configuration docs

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_b_685bae46f0288328adae5100d2ce8143