### PR TITLE
Add import folder persistence and file type column

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -57,6 +57,7 @@
         private System.Windows.Forms.ColumnHeader chName;
         private System.Windows.Forms.ColumnHeader chSize;
         private System.Windows.Forms.ColumnHeader chModified;
+        private System.Windows.Forms.ColumnHeader chType;
 
         private void InitializeComponent()
         {
@@ -83,6 +84,7 @@
             chName = new ColumnHeader();
             chSize = new ColumnHeader();
             chModified = new ColumnHeader();
+            chType = new ColumnHeader();
             pnlImportTop = new Panel();
             btnImportParse = new Button();
             btnImportRead = new Button();
@@ -330,7 +332,7 @@
             // 
             // lvImportFiles
             // 
-            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chSize, chModified });
+            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chSize, chModified, chType });
             lvImportFiles.Dock = DockStyle.Fill;
             lvImportFiles.FullRowSelect = true;
             lvImportFiles.Location = new Point(3, 35);
@@ -355,7 +357,12 @@
             // 
             chModified.Text = "Modified";
             chModified.Width = 200;
-            // 
+            //
+            // chType
+            //
+            chType.Text = "Type";
+            chType.Width = 120;
+            //
             // pnlImportTop
             // 
             pnlImportTop.Controls.Add(btnImportParse);

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Data;
 using RMCollectionProcessor.Models;
+using RMCollectionProcessor;
 
 namespace DCCollections.Gui
 {
@@ -308,6 +309,12 @@ namespace DCCollections.Gui
             {
                 txtTestOutputFolder.Text = _settings.TestOutputFolderPath;
             }
+
+            if (!string.IsNullOrWhiteSpace(_settings.ImportFolderPath) && Directory.Exists(_settings.ImportFolderPath))
+            {
+                txtImportFolder.Text = _settings.ImportFolderPath;
+                LoadImportFiles(_settings.ImportFolderPath);
+            }
         }
 
         private void LoadOperationsFiles(string path)
@@ -332,6 +339,7 @@ namespace DCCollections.Gui
             if (fbd.ShowDialog() == DialogResult.OK)
             {
                 txtImportFolder.Text = fbd.SelectedPath;
+                _settings.ImportFolderPath = fbd.SelectedPath;
                 LoadImportFiles(fbd.SelectedPath);
             }
         }
@@ -341,6 +349,7 @@ namespace DCCollections.Gui
             try
             {
                 lvImportFiles.Items.Clear();
+                var processor = new FileProcessor();
                 foreach (var file in Directory.GetFiles(path))
                 {
                     var info = new FileInfo(file);
@@ -351,6 +360,16 @@ namespace DCCollections.Gui
                     };
                     item.SubItems.Add(size);
                     item.SubItems.Add(info.LastWriteTime.ToString("yyyy-MM-dd HH:mm"));
+                    try
+                    {
+                        var parsed = processor.ProcessFile(info.FullName);
+                        var ft = FileTypeIdentifier.Identify(parsed);
+                        item.SubItems.Add(ft.ToString());
+                    }
+                    catch
+                    {
+                        item.SubItems.Add(FileType.Unknown.ToString());
+                    }
                     lvImportFiles.Items.Add(item);
                 }
             }

--- a/DCCollections.Gui/UserSettings.cs
+++ b/DCCollections.Gui/UserSettings.cs
@@ -8,6 +8,7 @@ namespace DCCollections.Gui
         public string? ParseFolderPath { get; set; }
         public string? LiveOutputFolderPath { get; set; }
         public string? TestOutputFolderPath { get; set; }
+        public string? ImportFolderPath { get; set; }
 
         private static string SettingsFile => Path.Combine(AppContext.BaseDirectory, "usersettings.json");
 


### PR DESCRIPTION
## Summary
- remember import folder path between sessions
- show previous import path on launch
- detect file type of import files and display it in a new column

## Testing
- `dotnet restore`
- `dotnet build DCCollections.Gui/DCCollections.Gui.csproj`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.csproj`
- `dotnet build DCCollections.Models/DC-Models-Identifier.csproj`


------
https://chatgpt.com/codex/tasks/task_b_685bbe512670832894995f4fcae8eefc