### PR TITLE
Add generation date/time columns and sort persistence

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -90,6 +90,8 @@
             tpImportFiles = new TabPage();
             lvImportFiles = new ListView();
             chName = new ColumnHeader();
+            chGenDate = new ColumnHeader();
+            chGenTime = new ColumnHeader();
             chSize = new ColumnHeader();
             chModified = new ColumnHeader();
             chType = new ColumnHeader();
@@ -399,7 +401,7 @@
             // 
             // lvImportFiles
             // 
-            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chSize, chModified, chType });
+            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chGenDate, chGenTime, chSize, chModified, chType });
             lvImportFiles.Dock = DockStyle.Fill;
             lvImportFiles.FullRowSelect = true;
             lvImportFiles.Location = new Point(3, 35);
@@ -409,14 +411,25 @@
             lvImportFiles.UseCompatibleStateImageBehavior = false;
             lvImportFiles.View = View.Details;
             lvImportFiles.SelectedIndexChanged += lvImportFiles_SelectedIndexChanged;
+            lvImportFiles.ColumnClick += lvImportFiles_ColumnClick;
             // 
             // chName
-            // 
+            //
             chName.Text = "Name";
             chName.Width = 400;
-            // 
+
+            // chGenDate
+            //
+            chGenDate.Text = "Gen Date";
+            chGenDate.Width = 100;
+
+            // chGenTime
+            //
+            chGenTime.Text = "Gen Time";
+            chGenTime.Width = 80;
+            //
             // chSize
-            // 
+            //
             chSize.Text = "Size";
             chSize.Width = 100;
             // 
@@ -531,5 +544,7 @@
         private Label label1;
         private Button btnCheckDuplicates;
         private DataGridView dgvPossibleDuplicates;
+        private ColumnHeader chGenDate;
+        private ColumnHeader chGenTime;
     }
 }

--- a/DCCollections.Gui/UserSettings.cs
+++ b/DCCollections.Gui/UserSettings.cs
@@ -9,6 +9,8 @@ namespace DCCollections.Gui
         public string? LiveOutputFolderPath { get; set; }
         public string? TestOutputFolderPath { get; set; }
         public string? ImportFolderPath { get; set; }
+        public int ImportSortColumn { get; set; }
+        public bool ImportSortDescending { get; set; }
 
         private static string SettingsFile => Path.Combine(AppContext.BaseDirectory, "usersettings.json");
 


### PR DESCRIPTION
## Summary
- extend user settings to keep import sorting preferences
- add generation date/time columns to lvImportFiles
- parse filenames to show generation info
- implement sortable listview and persist the configuration

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet test DCCollectionsRequest/DCCollectionsRequest.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_685bdc2f7108832898f4debd03a19841