### PR TITLE
Add preview context menu for import files

### DIFF
--- a/DCCollections.Gui/FilePreviewForm.cs
+++ b/DCCollections.Gui/FilePreviewForm.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+
+namespace DCCollections.Gui
+{
+    public class FilePreviewForm : Form
+    {
+        private readonly string _filePath;
+        private Label lblFileName;
+        private TextBox txtContent;
+        private Button btnOpenLocation;
+
+        public FilePreviewForm(string filePath)
+        {
+            _filePath = filePath;
+            InitializeComponent();
+            lblFileName.Text = Path.GetFileName(filePath);
+            try
+            {
+                txtContent.Text = File.ReadAllText(filePath);
+            }
+            catch (Exception ex)
+            {
+                txtContent.Text = ex.Message;
+            }
+        }
+
+        private void InitializeComponent()
+        {
+            lblFileName = new Label();
+            txtContent = new TextBox();
+            btnOpenLocation = new Button();
+            SuspendLayout();
+            // 
+            // lblFileName
+            // 
+            lblFileName.AutoSize = true;
+            lblFileName.Dock = DockStyle.Top;
+            lblFileName.Padding = new Padding(5);
+            lblFileName.Text = "File";
+            // 
+            // btnOpenLocation
+            // 
+            btnOpenLocation.Dock = DockStyle.Bottom;
+            btnOpenLocation.Text = "Open File Location";
+            btnOpenLocation.Height = 30;
+            btnOpenLocation.Click += BtnOpenLocation_Click;
+            // 
+            // txtContent
+            // 
+            txtContent.Multiline = true;
+            txtContent.ReadOnly = true;
+            txtContent.Dock = DockStyle.Fill;
+            txtContent.ScrollBars = ScrollBars.Both;
+            txtContent.Font = new System.Drawing.Font("Consolas", 9F);
+            // 
+            // FilePreviewForm
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(800, 600);
+            Controls.Add(txtContent);
+            Controls.Add(btnOpenLocation);
+            Controls.Add(lblFileName);
+            Text = "Preview";
+            StartPosition = FormStartPosition.CenterParent;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        private void BtnOpenLocation_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+                {
+                    Process.Start(new ProcessStartInfo("explorer.exe", dir) { UseShellExecute = true });
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+            }
+        }
+    }
+}

--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -58,6 +58,8 @@
         private System.Windows.Forms.ColumnHeader chSize;
         private System.Windows.Forms.ColumnHeader chModified;
         private System.Windows.Forms.ColumnHeader chType;
+        private System.Windows.Forms.ContextMenuStrip cmsImportFiles;
+        private System.Windows.Forms.ToolStripMenuItem previewToolStripMenuItem;
 
         private void InitializeComponent()
         {
@@ -102,6 +104,8 @@
             txtImportFolder = new TextBox();
             lblLiveOutput = new Label();
             lblTestOutput = new Label();
+            cmsImportFiles = new ContextMenuStrip(components);
+            previewToolStripMenuItem = new ToolStripMenuItem();
             tabMain.SuspendLayout();
             tabOperations.SuspendLayout();
             groupBox1.SuspendLayout();
@@ -110,6 +114,7 @@
             tabParse.SuspendLayout();
             tpImportFiles.SuspendLayout();
             pnlImportTop.SuspendLayout();
+            cmsImportFiles.SuspendLayout();
             SuspendLayout();
             // 
             // btnTestOutputOpen
@@ -412,6 +417,7 @@
             lvImportFiles.View = View.Details;
             lvImportFiles.SelectedIndexChanged += lvImportFiles_SelectedIndexChanged;
             lvImportFiles.ColumnClick += lvImportFiles_ColumnClick;
+            lvImportFiles.MouseUp += lvImportFiles_MouseUp;
             // 
             // chName
             //
@@ -511,9 +517,20 @@
             lblTestOutput.Size = new Size(113, 15);
             lblTestOutput.TabIndex = 10;
             lblTestOutput.Text = "Test Output Folder";
-            // 
+            //
+            // cmsImportFiles
+            //
+            cmsImportFiles.Items.AddRange(new ToolStripItem[] { previewToolStripMenuItem });
+            //
+            // previewToolStripMenuItem
+            //
+            previewToolStripMenuItem.Name = "previewToolStripMenuItem";
+            previewToolStripMenuItem.Size = new Size(116, 22);
+            previewToolStripMenuItem.Text = "Preview";
+            previewToolStripMenuItem.Click += previewToolStripMenuItem_Click;
+            //
             // MainForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1189, 637);
@@ -532,6 +549,7 @@
             tpImportFiles.ResumeLayout(false);
             pnlImportTop.ResumeLayout(false);
             pnlImportTop.PerformLayout();
+            cmsImportFiles.ResumeLayout(false);
             ResumeLayout(false);
         }
 

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -440,6 +440,40 @@ namespace DCCollections.Gui
             lvImportFiles.Sort();
         }
 
+        private void lvImportFiles_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Right)
+                return;
+
+            var hit = lvImportFiles.HitTest(e.Location);
+            if (hit.Item != null && hit.Item.SubItems.IndexOf(hit.SubItem) == 0)
+            {
+                lvImportFiles.SelectedItems.Clear();
+                hit.Item.Selected = true;
+                cmsImportFiles.Show(lvImportFiles, e.Location);
+            }
+        }
+
+        private void previewToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (lvImportFiles.SelectedItems.Count == 0)
+                return;
+
+            var path = lvImportFiles.SelectedItems[0].Tag as string;
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            try
+            {
+                using var form = new FilePreviewForm(path);
+                form.ShowDialog(this);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+            }
+        }
+
         private void btnImportParse_Click(object sender, EventArgs e)
         {
             if (lvImportFiles.SelectedItems.Count == 0)


### PR DESCRIPTION
## Summary
- add FilePreviewForm to show file content with an option to open the file's folder
- attach a context menu to `lvImportFiles` with a Preview command
- show the menu only when right-clicking the filename column

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`

------
https://chatgpt.com/codex/tasks/task_b_685bdf95378883288024e0c9ba3fe701