### PR TITLE
Fix null container crash in MainForm

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -63,6 +63,7 @@
 
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             btnTestOutputOpen = new Button();
             btnLiveOutputOpen = new Button();
             tabMain = new TabControl();


### PR DESCRIPTION
## Summary
- initialize the Windows Forms component container before use

## Testing
- `dotnet build DCCollectionsRequest/DCCollections.csproj`


------
https://chatgpt.com/codex/tasks/task_b_685be24bdce48328a2c1ca8cbe5a7dbd