### PR TITLE
Update bank file status when importing reports

### DIFF
--- a/DCCollections.Models/BankFileStatus.cs
+++ b/DCCollections.Models/BankFileStatus.cs
@@ -1,0 +1,17 @@
+namespace RMCollectionProcessor.Models
+{
+    /// <summary>
+    /// Represents the processing status of a bank file.
+    /// </summary>
+    public enum BankFileStatus
+    {
+        /// <summary>File has been accepted.</summary>
+        Accepted = 1,
+        /// <summary>File has been submitted but not yet accepted.</summary>
+        Submitted = 2,
+        /// <summary>File was rejected.</summary>
+        Rejected = 3,
+        /// <summary>File has been created but not yet submitted.</summary>
+        Created = 7
+    }
+}

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -46,7 +46,7 @@ namespace RMCollectionProcessor
                     {
                         int genNum = 0;
                         int.TryParse(statusRecords.First().GenerationNumber, out genNum);
-                        ImportReoprtFile(genNum);
+                        ImportReoprtFile(genNum, BankFileStatus.Accepted);
                     }
                     dbService.InsertCollectionResponses(statusRecords, filePath);
                     break;
@@ -360,9 +360,11 @@ namespace RMCollectionProcessor
         /// Placeholder for future implementation.
         /// </summary>
         /// <param name="generationNumber">The generation number extracted from the file.</param>
-        public void ImportReoprtFile(int generationNumber)
+        /// <param name="status">The status to apply to the bank file.</param>
+        public void ImportReoprtFile(int generationNumber, BankFileStatus status)
         {
-            // TODO: Implement report file import logic using the generation number.
+            var db = new DatabaseService();
+            db.UpdateBankFileStatus(generationNumber, status);
         }
     }
 }

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -219,6 +219,23 @@ END", conn);
         cmd.ExecuteNonQuery();
     }
 
+    /// <summary>
+    /// Updates the status of an existing bank file record using the generation number.
+    /// </summary>
+    /// <param name="generationNumber">The generation number of the bank file.</param>
+    /// <param name="status">The status to apply.</param>
+    public void UpdateBankFileStatus(int generationNumber, BankFileStatus status)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        using var cmd = new SqlCommand(@"UPDATE [DRC].[dbo].[EDI_BANKFILES]
+   SET STATUS = @STATUS
+ WHERE [EDI_BANKFILES].GENERATIONNUMBER = @GENERATIONNUMBER;", conn);
+        cmd.Parameters.Add(new SqlParameter("@STATUS", SqlDbType.VarChar, 4) { Value = ((int)status).ToString() });
+        cmd.Parameters.Add(new SqlParameter("@GENERATIONNUMBER", SqlDbType.Int) { Value = generationNumber });
+        conn.Open();
+        cmd.ExecuteNonQuery();
+    }
+
     public BillingCollectionRequest? GetCollectionRequestByReference(string reference)
     {
         using var conn = new SqlConnection(_connectionString);


### PR DESCRIPTION
## Summary
- add `BankFileStatus` enum
- add `UpdateBankFileStatus` method
- update collection service to set the status using generation number

## Testing
- `dotnet restore DCCollectionsRequest/DCCollections.csproj` *(fails: NuGet.Config is not valid)*
- `dotnet build DCCollectionsRequest/DCCollections.csproj --no-restore` *(fails: assets file missing)*

------
https://chatgpt.com/codex/tasks/task_b_685bf9cae7088328b61f27702d7d3a98