### PR TITLE
Handle reply files

### DIFF
--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -51,7 +51,15 @@ namespace RMCollectionProcessor
                     dbService.InsertCollectionResponses(statusRecords, filePath);
                     break;
                 case FileType.Reply:
-                    Console.Write("Unknown");
+                    var reply = parsed.OfType<ReplyTransmissionStatus900>().FirstOrDefault();
+                    if (reply != null)
+                    {
+                        int gen = 0;
+                        int.TryParse(reply.TransmissionNumber.Trim(), out gen);
+                        var st = reply.TransmissionStatus.Trim();
+                        var fileStatus = string.Equals(st, "ACCEPTED", StringComparison.OrdinalIgnoreCase) ? BankFileStatus.Submitted : BankFileStatus.Rejected;
+                        ImportReplyFile(gen, fileStatus);
+                    }
                     break;
                 case FileType.Unknown:
                     Console.Write("Unknown");


### PR DESCRIPTION
## Summary
- handle reply file import in CollectionService switch statement

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`

------
https://chatgpt.com/codex/tasks/task_b_685bff69de6c83289966a0b03a5c34dd