### PR TITLE
Fix EffectiveDate assignment

### DIFF
--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -98,7 +98,6 @@ namespace RMCollectionProcessor
                         GenerationNumber = generationNumber,
                         TransactionStatus = line1.TransactionStatus.Trim(),
                         ContractReference = line1.ContractReferenceNumber.Trim(),
-                       // OriginalPaymentInformation = line1.OriginalPmtInfId.Trim()
                     };
                 }
                 else if (currentTransaction != null)
@@ -106,7 +105,8 @@ namespace RMCollectionProcessor
                     if (record is StatusUserSetTransactionLine02 line2)
                     {
                         currentTransaction.ActionDate = line2.ActionDate.Trim();
-                        currentTransaction.EffectiveDate = line2.EffectiveDate.Trim();
+                        var trimmedEffectiveDate = line2.EffectiveDate.Trim();
+                        currentTransaction.EffectiveDate = string.IsNullOrEmpty(trimmedEffectiveDate) ? null : trimmedEffectiveDate;
                     }
                     else if (record is StatusUserSetTransactionLine03 line3)
                     {

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -414,13 +414,13 @@ END", conn);
 
             DateTime.TryParse(r.ActionDate, out var actionDate);
 
-            bool isValid = DateTime.TryParseExact(
+            bool isEffectiveDateValid = DateTime.TryParseExact(
                 r.EffectiveDate,
                 "yyyyMMdd",
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.None,
                 out var effectiveDate);
-            if (!isValid)
+            if (!isEffectiveDateValid)
             {
 
             }
@@ -430,7 +430,7 @@ END", conn);
             insertCmd.Parameters.Add(new SqlParameter("@reasonCode", SqlDbType.VarChar, 6) { Value = (object?)r.RejectReasonCode ?? DBNull.Value });
             insertCmd.Parameters.Add(new SqlParameter("@reasonDesc", SqlDbType.VarChar, 135) { Value = (object?)r.RejectReasonDescription ?? DBNull.Value });
             insertCmd.Parameters.Add(new SqlParameter("@actionDate", SqlDbType.DateTime) { Value = (object?)actionDate ?? DBNull.Value });
-            insertCmd.Parameters.Add(new SqlParameter("@effectiveDate", SqlDbType.DateTime) { Value = (object?)effectiveDate ?? DBNull.Value });
+            insertCmd.Parameters.Add(new SqlParameter("@effectiveDate", SqlDbType.DateTime) { Value = isEffectiveDateValid ? effectiveDate : DBNull.Value });
             insertCmd.Parameters.Add(new SqlParameter("@origContractRef", SqlDbType.VarChar, 14) { Value = r.ContractReference });
             insertCmd.Parameters.Add(new SqlParameter("@origPmtInfo", SqlDbType.VarChar, 35) { Value = r.OriginalPaymentInformation });
             try


### PR DESCRIPTION
## Summary
- treat empty EffectiveDate as null when consolidating status report transactions
- rename variable in `InsertCollectionResponses` for clarity and insert null into the database when the effective date is invalid

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_b_685c1846621083288926b1f0357813b6