### PR TITLE
Fix context menu selection in ListView

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -361,7 +361,7 @@ namespace DCCollections.Gui
                 return;
 
             var hit = lvImportFiles.HitTest(e.Location);
-            if (hit.Item != null && hit.Item.SubItems.IndexOf(hit.SubItem) == 0)
+            if (hit.Item != null)
             {
                 lvImportFiles.SelectedItems.Clear();
                 hit.Item.Selected = true;


### PR DESCRIPTION
## Summary
- show the import file context menu on right-click anywhere in the row

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_b_685c1c9544188328b6918287920ce435