### PR TITLE
Default hide test files

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -44,7 +44,6 @@ namespace DCCollections.Gui
         {
             InitializeComponent();
 
-            // Display the connection string (without the password) to the user
             var connStr = DbConnection.AppConfig.ConnectionString;
             if (!string.IsNullOrWhiteSpace(connStr))
             {
@@ -58,6 +57,7 @@ namespace DCCollections.Gui
             WindowState = FormWindowState.Maximized;
             MaximizeBox = true;
             chkTest.Checked = true;
+            chkHideTestFiles.Checked = true;
             LoadInitialPaths();
         }
 


### PR DESCRIPTION
## Summary
- hide test files by default when the Import Files tab is opened
- remove leftover comment in the constructor

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj -c Release` *(fails: requires network access)*

------
https://chatgpt.com/codex/tasks/task_b_685c1ebbdcc48328aac6bf7039dd58aa