### PR TITLE
Fix preview window size

### DIFF
--- a/DCCollections.Gui/FilePreviewForm.cs
+++ b/DCCollections.Gui/FilePreviewForm.cs
@@ -27,6 +27,13 @@ namespace DCCollections.Gui
             }
         }
 
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            var area = Screen.FromControl(this).WorkingArea;
+            Size = new System.Drawing.Size((int)(area.Width * 0.9), (int)(area.Height * 0.9));
+        }
+
         private void InitializeComponent()
         {
             lblFileName = new Label();


### PR DESCRIPTION
## Summary
- size `FilePreviewForm` based on screen when shown

## Testing
- `dotnet restore DCCollectionsRequest/DCCollections.csproj`
- `dotnet restore EFTRunner/EFTRunner.csproj`
- `dotnet restore DCCollections.Gui/Main.Gui.csproj`
- `dotnet build DCCollections.Gui/Main.Gui.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cf861664c8328810079234bd0a32f