### PR TITLE
Rename EFT Writer class to RecordBuilder

### DIFF
--- a/EFT-Collections/EftTransaction.cs
+++ b/EFT-Collections/EftTransaction.cs
@@ -4,7 +4,7 @@ namespace EFT_Collections
 {
     /// <summary>
     /// A logical representation of a single EFT transaction (a collection from a customer).
-    /// This class is used to pass dynamic transaction data to the Writer.
+    /// This class is used to pass dynamic transaction data to the RecordBuilder.
     /// </summary>
     public class EftTransaction
     {

--- a/EFT-Collections/RecordBuilder.cs
+++ b/EFT-Collections/RecordBuilder.cs
@@ -8,7 +8,7 @@ using FileHelpers;
 /// Generates EFT collection file content and writes it to disk.
 /// Logic previously embedded in <c>Program.cs</c> is now encapsulated here.
 /// </summary>
-public class Writer
+public class RecordBuilder
 {
     // Static Creditor Information
     private readonly string _clientCode;
@@ -24,7 +24,7 @@ public class Writer
     /// <summary>
     /// Initializes the writer with the static details of the creditor.
     /// </summary>
-    public Writer(string clientCode, string clientName, string bankservUserCode, string creditorBranch, string creditorAccount, string creditorAbbreviation, DateTime deductionDate, string recordStatus = "L", string typeOfService = "SAMEDAY")
+    public RecordBuilder(string clientCode, string clientName, string bankservUserCode, string creditorBranch, string creditorAccount, string creditorAbbreviation, DateTime deductionDate, string recordStatus = "L", string typeOfService = "SAMEDAY")
     {
         _clientCode = clientCode;
         _clientName = clientName;

--- a/EFTRunner/Program.cs
+++ b/EFTRunner/Program.cs
@@ -34,7 +34,7 @@ public class Program
             }
         }
 
-        var writer = new Writer(
+        var writer = new RecordBuilder(
             clientCode: creditorDefaults.clientCode,
             clientName: creditorDefaults.clientName,
             bankservUserCode: creditorDefaults.bankservUserCode,


### PR DESCRIPTION
## Summary
- rename `Writer.cs` to `RecordBuilder.cs` in EFT Collections
- adjust `EftTransaction` XML comments
- instantiate `RecordBuilder` in EFTRunner

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`

------
https://chatgpt.com/codex/tasks/task_b_685d1a91b56883289c85d4fdb2294a4e