### PR TITLE
Add daily counter initialization

### DIFF
--- a/DCCollections.Gui/Program.cs
+++ b/DCCollections.Gui/Program.cs
@@ -8,8 +8,10 @@ namespace DCCollections.Gui
         [STAThread]
         static void Main()
         {
-            // To customize application configuration such as set high DPI settings or default font,
-            // see https://aka.ms/applicationconfiguration.
+            var dcDb = new DatabaseService();
+            dcDb.EnsureDailyCounterForToday();
+            var eftDb = new EFT_Collections.DatabaseService();
+            eftDb.EnsureDailyCounterForTodayAsync().GetAwaiter().GetResult();
             ApplicationConfiguration.Initialize();
             Application.Run(new MainForm());
         }

--- a/EFTRunner/Program.cs
+++ b/EFTRunner/Program.cs
@@ -11,6 +11,8 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
+        var db = new DatabaseService();
+        await db.EnsureDailyCounterForTodayAsync();
         DateTime deductionDate = DateTime.Now;
         bool isTest =false;
         string fileName = "";


### PR DESCRIPTION
## Summary
- ensure daily counters are created on startup
- initialize counters when running the GUI or EFT console

## Testing
- `dotnet restore DCCollectionsRequest/DCCollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln`

------
https://chatgpt.com/codex/tasks/task_b_68626db5e58883289ac6fe44ef9694a0