### PR TITLE
Add counter display to operations tab

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -99,6 +99,10 @@
             cmsImportFiles = new ContextMenuStrip(components);
             previewToolStripMenuItem = new ToolStripMenuItem();
             grpCounters = new GroupBox();
+            lblDcGenerationNumber = new Label();
+            lblDcDailyCounter = new Label();
+            lblEftGenerationNumber = new Label();
+            lblEftDailyCounter = new Label();
             tabMain.SuspendLayout();
             tabOperations.SuspendLayout();
             grpConfig.SuspendLayout();
@@ -489,15 +493,40 @@
             // 
             // grpCounters
             // 
+            grpCounters.Controls.Add(lblEftDailyCounter);
+            grpCounters.Controls.Add(lblEftGenerationNumber);
+            grpCounters.Controls.Add(lblDcDailyCounter);
+            grpCounters.Controls.Add(lblDcGenerationNumber);
             grpCounters.Location = new Point(8, 262);
             grpCounters.Name = "grpCounters";
             grpCounters.Size = new Size(544, 337);
             grpCounters.TabIndex = 20;
             grpCounters.TabStop = false;
             grpCounters.Text = "Counters";
-            // 
-            // MainForm
-            // 
+            lblDcGenerationNumber.AutoSize = true;
+            lblDcGenerationNumber.Location = new Point(16, 22);
+            lblDcGenerationNumber.Name = "lblDcGenerationNumber";
+            lblDcGenerationNumber.Size = new Size(173, 15);
+            lblDcGenerationNumber.TabIndex = 0;
+            lblDcGenerationNumber.Text = "DC GenerationNumber: 0";
+            lblDcDailyCounter.AutoSize = true;
+            lblDcDailyCounter.Location = new Point(16, 47);
+            lblDcDailyCounter.Name = "lblDcDailyCounter";
+            lblDcDailyCounter.Size = new Size(145, 15);
+            lblDcDailyCounter.TabIndex = 1;
+            lblDcDailyCounter.Text = "DC DailyCounter: 0";
+            lblEftGenerationNumber.AutoSize = true;
+            lblEftGenerationNumber.Location = new Point(16, 72);
+            lblEftGenerationNumber.Name = "lblEftGenerationNumber";
+            lblEftGenerationNumber.Size = new Size(176, 15);
+            lblEftGenerationNumber.TabIndex = 2;
+            lblEftGenerationNumber.Text = "EFT GenerationNumber: 0";
+            lblEftDailyCounter.AutoSize = true;
+            lblEftDailyCounter.Location = new Point(16, 97);
+            lblEftDailyCounter.Name = "lblEftDailyCounter";
+            lblEftDailyCounter.Size = new Size(148, 15);
+            lblEftDailyCounter.TabIndex = 3;
+            lblEftDailyCounter.Text = "EFT DailyCounter: 0";
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1189, 637);
@@ -533,5 +562,9 @@
         private TextBox txtSearchFiles;
         private Button btnSearchFiles;
         private GroupBox grpCounters;
+        private Label lblDcGenerationNumber;
+        private Label lblDcDailyCounter;
+        private Label lblEftGenerationNumber;
+        private Label lblEftDailyCounter;
     }
 }

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using RMCollectionProcessor.Models;
 using RMCollectionProcessor;
 using EFT_Collections;
+using DCService = global::DatabaseService;
 
 namespace DCCollections.Gui
 {
@@ -68,6 +69,7 @@ namespace DCCollections.Gui
             tabOperations.Controls.Add(_pbOperations);
             lvImportFiles.MultiSelect = true;
             LoadInitialPaths();
+            LoadCounters();
         }
 
         private static string RemovePassword(string connection)
@@ -538,6 +540,32 @@ namespace DCCollections.Gui
             _settings.ImportSortColumn = _importSortColumn;
             _settings.ImportSortDescending = _importSortDescending;
             _settings.Save();
+        }
+
+        /// <summary>
+        /// Retrieves the latest counter values from the database and displays them.
+        /// </summary>
+        private void LoadCounters()
+        {
+            try
+            {
+                var dcDb = new DCService();
+                int dcGen = dcDb.GetCurrentGenerationNumber();
+                int dcDaily = dcDb.GetCurrentDailyCounter(DateTime.Today);
+
+                var eftDb = new EFT_Collections.DatabaseService();
+                int eftGen = eftDb.PeekGenerationNumberAsync().GetAwaiter().GetResult();
+                int eftDaily = eftDb.PeekDailyCounterAsync(DateTime.Today).GetAwaiter().GetResult();
+
+                lblDcGenerationNumber.Text = $"DC GenerationNumber: {dcGen}";
+                lblDcDailyCounter.Text = $"DC DailyCounter: {dcDaily}";
+                lblEftGenerationNumber.Text = $"EFT GenerationNumber: {eftGen}";
+                lblEftDailyCounter.Text = $"EFT DailyCounter: {eftDaily}";
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show EFT and DC counters on the operations tab
- fetch counters from the database in the GUI

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_b_68627606a478832884f612ac00c61dbb