### PR TITLE
Add file type folders and copy files

### DIFF
--- a/FileProcessor/Program.cs
+++ b/FileProcessor/Program.cs
@@ -32,6 +32,11 @@ namespace FileProcessor
                     var parsedRecords = processor.ProcessFile(file);
                     var fileType = FileTypeIdentifier.Identify(parsedRecords);
                     Console.WriteLine($"{Path.GetFileName(file)}: {fileType}");
+
+                    var destinationFolder = Path.Combine(sourceFolder, fileType.ToString());
+                    Directory.CreateDirectory(destinationFolder);
+                    var destinationPath = Path.Combine(destinationFolder, Path.GetFileName(file));
+                    File.Copy(file, destinationPath, true);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- create subfolders per file type in FileProcessor
- copy each processed file into the correct folder

## Testing
- `dotnet restore FileProcessor/FileProcessor.csproj`
- `dotnet build FileProcessor/FileProcessor.csproj`
- `for p in DCCollections.Models/DCModelsIdentifier.csproj FileProcessor/FileProcessor.csproj DCCollections.Gui/Main.Gui.csproj EFT-Collections/EFTCollections.csproj DbConnection/DbConnection.csproj EFTRunner/EFTRunner.csproj DCCollectionsRequest/DCCollections.csproj; do dotnet build "$p"; done`

------
https://chatgpt.com/codex/tasks/task_b_6862bac5c624832898234ab03ab6d8e2