### PR TITLE
Implement status-based sorting in FileProcessor CLI

### DIFF
--- a/FileProcessor/Program.cs
+++ b/FileProcessor/Program.cs
@@ -31,18 +31,37 @@ namespace FileProcessor
                 {
                     var parsedRecords = processor.ProcessFile(file);
                     var fileType = FileTypeIdentifier.Identify(parsedRecords);
-                    Console.WriteLine($"{Path.GetFileName(file)}: {fileType}");
-
-                    var destinationFolder = Path.Combine(sourceFolder, fileType.ToString());
+                    var status = GetRecordStatus(parsedRecords);
+                    var statusFolder = Path.Combine(sourceFolder, status == "L" ? "Live" : "Test");
+                    Directory.CreateDirectory(statusFolder);
+                    var destinationFolder = status == "L"
+                        ? Path.Combine(statusFolder, fileType.ToString())
+                        : statusFolder;
                     Directory.CreateDirectory(destinationFolder);
                     var destinationPath = Path.Combine(destinationFolder, Path.GetFileName(file));
                     File.Copy(file, destinationPath, true);
+                    Console.WriteLine($"{Path.GetFileName(file)}: {status} {fileType}");
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine($"Error processing file {Path.GetFileName(file)}: {ex.Message}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Retrieves the record status indicator from the parsed records.
+        /// </summary>
+        /// <param name="parsedRecords">An array of parsed record objects.</param>
+        /// <returns>"L" for live, "T" for test, or an empty string.</returns>
+        private static string GetRecordStatus(object[] parsedRecords)
+        {
+            if (parsedRecords.Length > 0 && parsedRecords[0] is TransmissionHeader000 th)
+            {
+                return th.RecordStatus?.Trim().ToUpperInvariant() ?? string.Empty;
+            }
+
+            return string.Empty;
         }
 
 


### PR DESCRIPTION
## Summary
- sort processed files into `Test` or `Live` subfolders
- inside `Live`, sort by detected file type
- show file status when copying files

## Testing
- `dotnet build FileProcessor/FileProcessor.csproj`

------
https://chatgpt.com/codex/tasks/task_b_6862bd8aa57883288959aefa220b63e7