### PR TITLE
Connect FileProcessor to DB for reply lookup

### DIFF
--- a/FileProcessor/FileProcessor.csproj
+++ b/FileProcessor/FileProcessor.csproj
@@ -2,6 +2,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DCCollections.Models\DCModelsIdentifier.csproj" />
+    <ProjectReference Include="..\DbConnection\DbConnection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- reference DbConnection in FileProcessor for configuration
- install Microsoft.Data.SqlClient
- query EDI_BANKFILES for reply generation numbers

## Testing
- `dotnet restore FileProcessor/FileProcessor.csproj`
- `dotnet build FileProcessor/FileProcessor.csproj`

------
https://chatgpt.com/codex/tasks/task_b_6862c3c3bc8c8328a960257277dd1afc