### PR TITLE
Display inserted status records

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -109,7 +109,12 @@ namespace DCCollections.Gui
                     var result = _dcCollectionservice.ParseFile(ofd.FileName);
                     _parsedRecords = result.Records;
                     _currentFileType = result.FileType;
-                    MessageBox.Show($"Parsed {_parsedRecords.Length} records (Type: {_currentFileType}).", "Success");
+                    var msg = $"Parsed {_parsedRecords.Length} records (Type: {_currentFileType}).";
+                    if (_currentFileType == FileType.StatusReport)
+                    {
+                        msg += $" Inserted {result.StatusRecordsInserted} of {result.StatusRecordsFound} status records.";
+                    }
+                    MessageBox.Show(msg, "Success");
                 }
                 catch (Exception ex)
                 {

--- a/DCCollections.Models/ParseResult.cs
+++ b/DCCollections.Models/ParseResult.cs
@@ -3,5 +3,5 @@ namespace RMCollectionProcessor.Models
     /// <summary>
     /// Represents the outcome of parsing a file.
     /// </summary>
-    public record ParseResult(object[] Records, FileType FileType);
+    public record ParseResult(object[] Records, FileType FileType, int StatusRecordsFound = 0, int StatusRecordsInserted = 0);
 }

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -34,6 +34,8 @@ namespace RMCollectionProcessor
 
             var fileType = FileTypeIdentifier.Identify(parsed);
             var dbService = new DatabaseService();
+            int statusFound = 0;
+            int statusInserted = 0;
             switch (fileType)
             {
                 case FileType.CollectionRequest:
@@ -43,8 +45,8 @@ namespace RMCollectionProcessor
                     break;
                 case FileType.StatusReport:
                     var statusRecords = ProcessStatusReport(parsed);
-                 
-                    dbService.InsertCollectionResponses(statusRecords, filePath);
+                    statusFound = statusRecords.Count();
+                    statusInserted = dbService.InsertCollectionResponses(statusRecords, filePath);
                     break;
                 case FileType.Reply:
                     var reply = parsed.OfType<ReplyTransmissionStatus900>().FirstOrDefault();
@@ -65,7 +67,7 @@ namespace RMCollectionProcessor
                     break;
             }
 
-            return new ParseResult(parsed, fileType);
+            return new ParseResult(parsed, fileType, statusFound, statusInserted);
         }
 
         /// <summary>

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -381,10 +381,11 @@ END", conn);
     /// </summary>
     /// <param name="statusRecords">A collection of transaction data from the status report.</param>
     /// <param name="filePath">The path of the status report file being processed.</param>
-    public void InsertCollectionResponses(IEnumerable<StatusReportTransaction> statusRecords, string filePath)
+    public int InsertCollectionResponses(IEnumerable<StatusReportTransaction> statusRecords, string filePath)
     {
         var recordList = statusRecords.ToList();
-        if (!recordList.Any()) return;
+        int inserted = 0;
+        if (!recordList.Any()) return inserted;
 
         string fileName = Path.GetFileName(filePath);
         int bankFileRowId = GetBankFileRowId(fileName);
@@ -467,11 +468,10 @@ END", conn);
             try
             {
                 insertCmd.ExecuteNonQuery();
+                inserted++;
             }
             catch (Exception ex)
             {
-
-                //throw;
             }
 
             existingResponses.Add(r.OriginalPaymentInformation);
@@ -484,5 +484,7 @@ END", conn);
             updateCmd.Parameters.Add(new SqlParameter("@reqId", SqlDbType.Int) { Value = originalRequestRowId });
             updateCmd.ExecuteNonQuery();
         }
+
+        return inserted;
     }
 }


### PR DESCRIPTION
## Summary
- report status record insert counts in GUI
- return inserted count from DatabaseService
- include counts in ParseResult
- show status file summary when parsing

## Testing
- `dotnet build DCCollectionsRequest/DCCollectionsRequest.sln --nologo`

------
https://chatgpt.com/codex/tasks/task_b_68639783b1a48328bfa784613049d4e2