### PR TITLE
Remove file input filters

### DIFF
--- a/DCCollections.Gui/Viewers/viewer.html
+++ b/DCCollections.Gui/Viewers/viewer.html
@@ -81,7 +81,7 @@
 <body>
 
     <h1>Fixed-Width File Viewer</h1>
-    <input type="file" id="fileInput" accept=".txt,.*">
+    <input type="file" id="fileInput">
     <div id="output"></div>
 
     <script>

--- a/DCCollectionsRequest/viewer.html
+++ b/DCCollectionsRequest/viewer.html
@@ -81,7 +81,7 @@
 <body>
 
     <h1>Fixed-Width File Viewer</h1>
-    <input type="file" id="fileInput" accept=".txt,.*">
+    <input type="file" id="fileInput">
     <div id="output"></div>
 
     <script>

--- a/EFT-Collections/viewer.html
+++ b/EFT-Collections/viewer.html
@@ -150,11 +150,11 @@
     <div id="controls">
         <div>
             <label for="baseFileInput"><strong>Base File:</strong></label>
-            <input type="file" id="baseFileInput" accept=".txt,.dat">
+            <input type="file" id="baseFileInput">
         </div>
         <div>
             <label for="newFileInput"><strong>New File:</strong></label>
-            <input type="file" id="newFileInput" accept=".txt,.dat">
+            <input type="file" id="newFileInput">
         </div>
         <button id="compareBtn" disabled>Compare Files</button>
     </div>


### PR DESCRIPTION
## Summary
- allow all file types for the file pickers by removing the `accept` attribute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68665f8628bc8328974d2fa69c78a532