### PR TITLE
Add file filter and search on import tab

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -96,6 +96,10 @@
             btnImportParse = new Button();
             btnImportRead = new Button();
             txtSearchFiles = new TextBox();
+            btnFindText = new Button();
+            txtFindText = new TextBox();
+            btnApplyFilter = new Button();
+            txtFileFilter = new TextBox();
             btnImportBrowse = new Button();
             txtImportFolder = new TextBox();
             chkHideTestFiles = new CheckBox();
@@ -444,13 +448,17 @@
             pnlImportTop.Controls.Add(btnImportRead);
             pnlImportTop.Controls.Add(btnSearchFiles);
             pnlImportTop.Controls.Add(txtSearchFiles);
+            pnlImportTop.Controls.Add(btnFindText);
+            pnlImportTop.Controls.Add(txtFindText);
+            pnlImportTop.Controls.Add(btnApplyFilter);
+            pnlImportTop.Controls.Add(txtFileFilter);
             pnlImportTop.Controls.Add(btnImportBrowse);
             pnlImportTop.Controls.Add(txtImportFolder);
             pnlImportTop.Controls.Add(chkHideTestFiles);
             pnlImportTop.Dock = DockStyle.Top;
             pnlImportTop.Location = new Point(3, 3);
             pnlImportTop.Name = "pnlImportTop";
-            pnlImportTop.Size = new Size(1175, 32);
+            pnlImportTop.Size = new Size(1175, 60);
             pnlImportTop.TabIndex = 0;
             // 
             // btnImportParse
@@ -481,6 +489,28 @@
             txtSearchFiles.Name = "txtSearchFiles";
             txtSearchFiles.Size = new Size(150, 23);
             txtSearchFiles.TabIndex = 5;
+            btnFindText.Location = new Point(821, 33);
+            btnFindText.Name = "btnFindText";
+            btnFindText.Size = new Size(100, 23);
+            btnFindText.TabIndex = 10;
+            btnFindText.Text = "Find Text";
+            btnFindText.UseVisualStyleBackColor = true;
+            btnFindText.Click += btnFindText_Click;
+            txtFindText.Location = new Point(615, 34);
+            txtFindText.Name = "txtFindText";
+            txtFindText.Size = new Size(200, 23);
+            txtFindText.TabIndex = 9;
+            btnApplyFilter.Location = new Point(509, 33);
+            btnApplyFilter.Name = "btnApplyFilter";
+            btnApplyFilter.Size = new Size(100, 23);
+            btnApplyFilter.TabIndex = 8;
+            btnApplyFilter.Text = "Apply";
+            btnApplyFilter.UseVisualStyleBackColor = true;
+            btnApplyFilter.Click += btnApplyFilter_Click;
+            txtFileFilter.Location = new Point(3, 34);
+            txtFileFilter.Name = "txtFileFilter";
+            txtFileFilter.Size = new Size(500, 23);
+            txtFileFilter.TabIndex = 7;
             // 
             // btnImportBrowse
             // 
@@ -579,6 +609,10 @@
         private CheckBox chkHideTestFiles;
         private TextBox txtSearchFiles;
         private Button btnSearchFiles;
+        private TextBox txtFindText;
+        private Button btnFindText;
+        private TextBox txtFileFilter;
+        private Button btnApplyFilter;
         private GroupBox grpCounters;
         private Label lblDcGenerationNumber;
         private Label lblDcDailyCounter;

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -340,6 +340,7 @@ namespace DCCollections.Gui
                 lvImportFiles.Items.Clear();
 
                 bool hideTests = chkHideTestFiles.Checked;
+                string nameFilter = txtFileFilter.Text.Trim();
 
                 var processor = new FileProcessor();
                 var eftIdentifier = new EftFileIdentifier();
@@ -347,6 +348,9 @@ namespace DCCollections.Gui
                 foreach (var file in Directory.GetFiles(path))
                 {
                     var info = new FileInfo(file);
+                    if (!string.IsNullOrEmpty(nameFilter) &&
+                        !info.Name.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+                        continue;
                     var size = info.Length > 1024 ? $"{info.Length / 1024} KB" : $"{info.Length} bytes";
                     DCFileType dcType = DCFileType.Unknown;
                     EftFileType eftType = EftFileType.Unknown;
@@ -660,6 +664,48 @@ namespace DCCollections.Gui
                 bool match = !string.IsNullOrEmpty(term) &&
                              item.SubItems.Cast<ListViewItem.ListViewSubItem>()
                                  .Any(sub => sub.Text.Contains(term, StringComparison.OrdinalIgnoreCase));
+                item.BackColor = match ? Color.Yellow : lvImportFiles.BackColor;
+            }
+        }
+
+        private void btnApplyFilter_Click(object sender, EventArgs e)
+        {
+            if (Directory.Exists(txtImportFolder.Text))
+            {
+                LoadImportFiles(txtImportFolder.Text);
+            }
+        }
+
+        private void btnFindText_Click(object sender, EventArgs e)
+        {
+            string term = txtFindText.Text.Trim();
+
+            foreach (ListViewItem item in lvImportFiles.Items)
+            {
+                bool match = false;
+                if (!string.IsNullOrEmpty(term))
+                {
+                    var tagObj = item.Tag;
+                    string? path = null;
+                    if (tagObj is ImportFileTag tag)
+                        path = tag.Path;
+                    else
+                        path = tagObj as string;
+
+                    if (!string.IsNullOrWhiteSpace(path))
+                    {
+                        try
+                        {
+                            var text = File.ReadAllText(path);
+                            match = text.Contains(term, StringComparison.OrdinalIgnoreCase);
+                        }
+                        catch
+                        {
+                            match = false;
+                        }
+                    }
+                }
+
                 item.BackColor = match ? Color.Yellow : lvImportFiles.BackColor;
             }
         }


### PR DESCRIPTION
## Summary
- expand import panel height
- add file name filter and text search controls
- support filtering when loading import files
- highlight files containing search text

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_b_6877623dbe788328831ea65a100e7e6f