### PR TITLE
Add test and imported columns to import file list

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -51,6 +51,8 @@
         private System.Windows.Forms.ColumnHeader chSize;
         private System.Windows.Forms.ColumnHeader chModified;
         private System.Windows.Forms.ColumnHeader chType;
+        private System.Windows.Forms.ColumnHeader chTest;
+        private System.Windows.Forms.ColumnHeader chImported;
 
         private System.Windows.Forms.ContextMenuStrip cmsImportFiles;
         private System.Windows.Forms.ToolStripMenuItem previewToolStripMenuItem;
@@ -92,6 +94,8 @@
             chSize = new ColumnHeader();
             chModified = new ColumnHeader();
             chType = new ColumnHeader();
+            chTest = new ColumnHeader();
+            chImported = new ColumnHeader();
             pnlImportTop = new Panel();
             btnImportParse = new Button();
             btnImportRead = new Button();
@@ -399,7 +403,7 @@
             // 
             // lvImportFiles
             // 
-            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chGenDate, chGenTime, chSize, chModified, chType });
+            lvImportFiles.Columns.AddRange(new ColumnHeader[] { chName, chGenDate, chGenTime, chSize, chModified, chType, chTest, chImported });
             lvImportFiles.Dock = DockStyle.Fill;
             lvImportFiles.FullRowSelect = true;
             lvImportFiles.Location = new Point(3, 35);
@@ -441,9 +445,19 @@
             // 
             chType.Text = "Type";
             chType.Width = 120;
-            // 
+            //
+            // chTest
+            //
+            chTest.Text = "Test";
+            chTest.Width = 60;
+            //
+            // chImported
+            //
+            chImported.Text = "Imported";
+            chImported.Width = 80;
+            //
             // pnlImportTop
-            // 
+            //
             pnlImportTop.Controls.Add(btnImportParse);
             pnlImportTop.Controls.Add(btnImportRead);
             pnlImportTop.Controls.Add(btnSearchFiles);

--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -292,6 +292,8 @@ namespace DCCollections.Gui
 
             _importSortColumn = _settings.ImportSortColumn;
             _importSortDescending = _settings.ImportSortDescending;
+            if (_importSortColumn >= lvImportFiles.Columns.Count)
+                _importSortColumn = 0;
 
             if (!string.IsNullOrWhiteSpace(_settings.ImportFolderPath) && Directory.Exists(_settings.ImportFolderPath))
             {
@@ -344,6 +346,7 @@ namespace DCCollections.Gui
 
                 var processor = new FileProcessor();
                 var eftIdentifier = new EftFileIdentifier();
+                var db = new DCService();
 
                 foreach (var file in Directory.GetFiles(path))
                 {
@@ -413,6 +416,10 @@ namespace DCCollections.Gui
                         var eftTypeStr = eftType != EftFileType.Unknown ? eftType.ToString() : DCFileType.Unknown.ToString();
                         item.SubItems.Add(eftTypeStr);
                     }
+
+                    item.SubItems.Add(isLive ? "No" : "Yes");
+                    bool imported = db.GetBankFileRowId(info.Name) > 0;
+                    item.SubItems.Add(imported ? "Yes" : "No");
 
                     lvImportFiles.Items.Add(item);
                 }
@@ -581,6 +588,8 @@ namespace DCCollections.Gui
                             totalInserted += result.StatusRecordsInserted;
                         }
                     }
+
+                    item.SubItems[item.SubItems.Count - 1].Text = "Yes";
                 }
 
                 var msg = "Import complete.";


### PR DESCRIPTION
## Summary
- add Test and Imported columns to the import file view
- indicate file test status and import status when loading
- preserve valid sort column index
- mark files as imported after successful parse

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_b_6879e9f5f3e083289b434929c61d4ff9