### PR TITLE
Add billing date dropdown and pass effective date to query

### DIFF
--- a/DCCollections.Gui/MainForm.Designer.cs
+++ b/DCCollections.Gui/MainForm.Designer.cs
@@ -86,6 +86,8 @@
             rdoEft = new RadioButton();
             btnGenerate = new Button();
             nudDay = new NumericUpDown();
+            cmbBillingDate = new ComboBox();
+            label4 = new Label();
             tpImportFiles = new TabPage();
             lvImportFiles = new ListView();
             chName = new ColumnHeader();
@@ -173,6 +175,8 @@
             tabOperations.Controls.Add(dgvPossibleDuplicates);
             tabOperations.Controls.Add(btnCheckDuplicates);
             tabOperations.Controls.Add(chkTest);
+            tabOperations.Controls.Add(cmbBillingDate);
+            tabOperations.Controls.Add(label4);
             tabOperations.Controls.Add(rdoDebiCheck);
             tabOperations.Controls.Add(rdoEft);
             tabOperations.Controls.Add(btnGenerate);
@@ -242,6 +246,12 @@
             label3.Size = new Size(85, 15);
             label3.TabIndex = 15;
             label3.Text = "Deduction Day";
+            label4.AutoSize = true;
+            label4.Location = new Point(77, 82);
+            label4.Name = "label4";
+            label4.Size = new Size(73, 15);
+            label4.TabIndex = 21;
+            label4.Text = "Billing Date";
             // 
             // grpConfig
             // 
@@ -388,9 +398,13 @@
             nudDay.Size = new Size(38, 23);
             nudDay.TabIndex = 1;
             nudDay.Value = new decimal(new int[] { 1, 0, 0, 0 });
-            // 
+            cmbBillingDate.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbBillingDate.FormattingEnabled = true;
+            cmbBillingDate.Location = new Point(251, 79);
+            cmbBillingDate.Name = "cmbBillingDate";
+            cmbBillingDate.Size = new Size(121, 23);
+            cmbBillingDate.TabIndex = 5;
             // tpImportFiles
-            // 
             tpImportFiles.Controls.Add(lvImportFiles);
             tpImportFiles.Controls.Add(pnlImportTop);
             tpImportFiles.Location = new Point(4, 24);
@@ -632,5 +646,7 @@
         private Label lblDcDailyCounter;
         private Label lblEftGenerationNumber;
         private Label lblEftDailyCounter;
+        private ComboBox cmbBillingDate;
+        private Label label4;
     }
 }

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -147,14 +147,14 @@ namespace RMCollectionProcessor
         }
 
 
-        public FileGenerationResult GenerateDCFile(int deductionDay, bool isTest = false, string? outputFolder = null)
+        public FileGenerationResult GenerateDCFile(int deductionDay, DateTime effectiveBillingsDate, bool isTest = false, string? outputFolder = null)
         {
             if (deductionDay < 1 || deductionDay > 31)
                 throw new ArgumentOutOfRangeException(nameof(deductionDay), "Deduction day must be between 1 and 31.");
 
             var dbService = new DatabaseService();
 
-            var collections = dbService.GetCollections(deductionDay);
+            var collections = dbService.GetCollections(deductionDay, effectiveBillingsDate);
             if (!collections.Any())
                 throw new InvalidOperationException("No collections to process.");
 
@@ -306,10 +306,10 @@ namespace RMCollectionProcessor
             return dbService.GetCollectionRequestByReference(reference);
         }
 
-        public DataTable GetDuplicateCollections(int deductionDay)
+        public DataTable GetDuplicateCollections(int deductionDay, DateTime effectiveBillingsDate)
         {
             var dbService = new DatabaseService();
-            return dbService.GetDuplicateCollections(deductionDay);
+            return dbService.GetDuplicateCollections(deductionDay, effectiveBillingsDate);
         }
 
         private IEnumerable<TransactionRecord> ExtractTransactionRecords(string filePath, object[] parsed)

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -25,12 +25,13 @@ public class DatabaseService
         _creditorDefaultsSql = File.ReadAllText(Path.Combine(queriesPath, "CreditorDefaults.sql"));
     }
 
-    public List<DebtorCollectionData> GetCollections(int deductionDay)
+    public List<DebtorCollectionData> GetCollections(int deductionDay, DateTime effectiveBillingsDate)
     {
         var results = new List<DebtorCollectionData>();
         using var conn = new SqlConnection(_connectionString);
         using var cmd = new SqlCommand(_collectionsSql, conn);
-        cmd.Parameters.Add(new SqlParameter("@DEDUCTIONDAY", SqlDbType.Int) { Value = deductionDay });
+        cmd.Parameters.Add(new SqlParameter("@DeductionDay", SqlDbType.Int) { Value = deductionDay });
+        cmd.Parameters.Add(new SqlParameter("@EffectiveBillingsDate", SqlDbType.Date) { Value = effectiveBillingsDate.Date });
         conn.Open();
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
@@ -64,9 +65,9 @@ public class DatabaseService
         return results;
     }
 
-    public DataTable GetDuplicateCollections(int deductionDay)
+    public DataTable GetDuplicateCollections(int deductionDay, DateTime effectiveBillingsDate)
     {
-        var collections = GetCollections(deductionDay);
+        var collections = GetCollections(deductionDay, effectiveBillingsDate);
         var table = new DataTable();
         table.Columns.Add("ContractReference", typeof(string));
         table.Columns.Add("RequestedCollectionDate", typeof(DateTime));


### PR DESCRIPTION
## Summary
- add billing date dropdown on Operations tab
- populate upcoming billing months
- update DebiCheck generation to use selected date
- update SQL service methods to accept EffectiveBillingsDate

## Testing
- `dotnet restore DCCollectionsRequest/CollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/CollectionsRequest.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_b_688095f5b5348328be4e0f78492c57fc