### PR TITLE
Optimize collection request retrieval

### DIFF
--- a/DCCollections.Gui/MainForm.cs
+++ b/DCCollections.Gui/MainForm.cs
@@ -173,11 +173,12 @@ namespace DCCollections.Gui
                     var start = dtStartCollectionDate.Value.Date;
                     var end = dtEndCollectionDate.Value.Date;
                     var collections = _dcCollectionservice.GetCollections(day, effDate);
+                    var requests = _dcCollectionservice.GetCollectionRequests(start, end);
                     var existing = new Dictionary<string, List<BillingCollectionRequest>>();
                     foreach (var c in collections)
                     {
                         string sub = "MGS" + c.ContractReference;
-                        var list = _dcCollectionservice.GetCollectionRequests(sub, start, end);
+                        var list = requests.Where(r => r.SubSSN == sub).ToList();
                         if (list.Any())
                             existing[sub] = list;
                     }

--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -317,10 +317,10 @@ namespace RMCollectionProcessor
             return dbService.GetCollections(deductionDay, effectiveBillingsDate);
         }
 
-        public List<BillingCollectionRequest> GetCollectionRequests(string subssn, DateTime startDate, DateTime endDate)
+        public List<BillingCollectionRequest> GetCollectionRequests(DateTime startDate, DateTime endDate)
         {
             var dbService = new DatabaseService();
-            return dbService.GetCollectionRequests(subssn, startDate, endDate);
+            return dbService.GetCollectionRequests(startDate, endDate);
         }
 
         private IEnumerable<TransactionRecord> ExtractTransactionRecords(string filePath, object[] parsed)


### PR DESCRIPTION
## Summary
- remove SubSSN filter from `GetCollectionRequests`
- capture DB values before constructing `BillingCollectionRequest`
- update `CollectionService` wrapper
- fetch all requests once in MainForm

## Testing
- `dotnet restore DCCollectionsRequest/CollectionsRequest.sln`
- `dotnet build DCCollectionsRequest/CollectionsRequest.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_b_688b33b2666883289454bdb7cff73e4a