### PR TITLE
Add filtering and totals to ConfirmCollectionsForm

### DIFF
--- a/DCCollections.Gui/ConfirmCollectionsForm.cs
+++ b/DCCollections.Gui/ConfirmCollectionsForm.cs
@@ -11,6 +11,11 @@ namespace DCCollections.Gui
         private readonly DataGridView _grid;
         private readonly Button _btnOk;
         private readonly Button _btnCancel;
+        private readonly Button _btnSelectAll;
+        private readonly Button _btnSelectNone;
+        private readonly TextBox _txtFilter;
+        private readonly Label _lblColumns;
+        private readonly FlowLayoutPanel _panelTop;
         private readonly List<DebtorCollectionData> _collections;
 
         public List<DebtorCollectionData> SelectedCollections { get; } = new();
@@ -25,14 +30,35 @@ namespace DCCollections.Gui
             _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Amount" });
             _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Date" });
             _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Previous" });
+            _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Total" });
+
+            _btnSelectAll = new Button { Text = "Select All" };
+            _btnSelectNone = new Button { Text = "Select None" };
+            _txtFilter = new TextBox { Width = 100 };
+            _lblColumns = new Label
+            {
+                Text = "Include, SubSSN, Reference, Amount, Date, Previous, Total",
+                Dock = DockStyle.Top,
+                AutoSize = true
+            };
+            _panelTop = new FlowLayoutPanel { Dock = DockStyle.Top, AutoSize = true };
+            _panelTop.Controls.Add(new Label { Text = "Filter SubSSN:", AutoSize = true });
+            _panelTop.Controls.Add(_txtFilter);
+            _panelTop.Controls.Add(_btnSelectAll);
+            _panelTop.Controls.Add(_btnSelectNone);
 
             _btnOk = new Button { Text = "OK", DialogResult = DialogResult.OK, Dock = DockStyle.Bottom, Height = 30 };
             _btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Dock = DockStyle.Bottom, Height = 30 };
             _btnOk.Click += BtnOk_Click;
+            _btnSelectAll.Click += BtnSelectAll_Click;
+            _btnSelectNone.Click += BtnSelectNone_Click;
+            _txtFilter.TextChanged += FilterRows;
 
             Controls.Add(_grid);
             Controls.Add(_btnCancel);
             Controls.Add(_btnOk);
+            Controls.Add(_lblColumns);
+            Controls.Add(_panelTop);
             Text = "Confirm Collections";
             StartPosition = FormStartPosition.CenterParent;
             Width = 800;
@@ -42,11 +68,13 @@ namespace DCCollections.Gui
             {
                 string sub = "MGS" + col.ContractReference;
                 string hist = string.Empty;
+                decimal total = col.InstructedAmount;
                 if (existing.TryGetValue(sub, out var list) && list.Any())
                 {
                     hist = string.Join(", ", list.Select(r => r.DateRequested.ToString("yyyy-MM-dd")));
+                    total += list.Sum(r => decimal.TryParse(r.AmountRequested, out var a) ? a : 0m);
                 }
-                _grid.Rows.Add(true, sub, col.ContractReference, col.InstructedAmount.ToString("F2"), col.RequestedCollectionDate.ToString("yyyy-MM-dd"), hist);
+                _grid.Rows.Add(true, sub, col.ContractReference, col.InstructedAmount.ToString("F2"), col.RequestedCollectionDate.ToString("yyyy-MM-dd"), hist, total.ToString("F2"));
             }
         }
 
@@ -56,6 +84,33 @@ namespace DCCollections.Gui
             {
                 if (Convert.ToBoolean(_grid.Rows[i].Cells[0].Value))
                     SelectedCollections.Add(_collections[i]);
+            }
+        }
+
+        private void BtnSelectAll_Click(object? sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in _grid.Rows)
+            {
+                if (row.Visible)
+                    row.Cells[0].Value = true;
+            }
+        }
+
+        private void BtnSelectNone_Click(object? sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in _grid.Rows)
+            {
+                if (row.Visible)
+                    row.Cells[0].Value = false;
+            }
+        }
+
+        private void FilterRows(object? sender, EventArgs e)
+        {
+            string text = _txtFilter.Text.Trim();
+            foreach (DataGridViewRow row in _grid.Rows)
+            {
+                row.Visible = string.IsNullOrEmpty(text) || row.Cells[1].Value?.ToString()?.Contains(text, StringComparison.OrdinalIgnoreCase) == true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- enhance **ConfirmCollectionsForm** with filtering and total amounts
- add select all/none buttons and SubSSN filter box
- display column explanation label
- compute monthly total per SubSSN

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj`
- `dotnet test DCCollectionsRequest/CollectionsRequest.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_688b3aedfe888328a89de6f9b2dd8d4c