### PR TITLE
Store bank files in CPS file store

### DIFF
--- a/DCCollectionsRequest/CollectionService.cs
+++ b/DCCollectionsRequest/CollectionService.cs
@@ -290,6 +290,7 @@ namespace RMCollectionProcessor
             int inserted = 0;
             if (!isTest)
             {
+                dbService.LinkFileToBankFile(fileRowId, fullPath);
                 var txRecords = ExtractTransactionRecords(fullPath, records.ToArray());
                 inserted = dbService.InsertCollectionRequests(txRecords, fileRowId);
                 dbService.MarkBankFileGenerationComplete(fileRowId);

--- a/DCCollectionsRequest/DCCollections.csproj
+++ b/DCCollectionsRequest/DCCollections.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DCCollections.Models\DCModelsIdentifier.csproj" />
     <ProjectReference Include="..\tmp\PAMC.DatabaseConnection\PAMC.DatabaseConnection.csproj" />
+    <ProjectReference Include="..\tmp\CPS.FileStorage\CPS.FileStorage.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using RMCollectionProcessor.Models;
 using RMCollectionProcessor;
 using System.Globalization;
+using CPS.FileStorage;
 
 public class DatabaseService
 {
@@ -355,6 +356,49 @@ END", conn);
         cmd.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = rowId });
         conn.Open();
         cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Ensures the specified file is stored and linked to the bank file record.
+    /// </summary>
+    public void LinkFileToBankFile(int bankFileRowId, string filePath)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        conn.Open();
+        Guid? existingId = null;
+        using (var cmd = new SqlCommand("SELECT FILEID, FILENAME FROM dbo.EDI_BANKFILES WHERE ROWID = @id", conn))
+        {
+            cmd.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = bankFileRowId });
+            using var reader = cmd.ExecuteReader();
+            if (reader.Read())
+            {
+                existingId = reader["FILEID"] as Guid?;
+                var fileName = reader["FILENAME"].ToString() ?? string.Empty;
+                reader.Close();
+                if (existingId.HasValue)
+                {
+                    using var checkCmd = new SqlCommand("SELECT 1 FROM CPS_FILES WHERE ID = @fid", conn);
+                    checkCmd.Parameters.Add(new SqlParameter("@fid", SqlDbType.UniqueIdentifier) { Value = existingId.Value });
+                    var exists = checkCmd.ExecuteScalar();
+                    if (exists != null) return;
+                }
+                Guid fileId;
+                using (var lookup = new SqlCommand("SELECT ID FROM CPS_FILES WHERE FILENAME = @name", conn))
+                {
+                    lookup.Parameters.Add(new SqlParameter("@name", SqlDbType.VarChar, 100) { Value = fileName });
+                    var res = lookup.ExecuteScalar();
+                    fileId = res != null ? (Guid)res : Guid.Empty;
+                }
+                if (fileId == Guid.Empty)
+                {
+                    fileId = Utils.SaveFile(filePath, _connectionString);
+                }
+                using var update = new SqlCommand("UPDATE dbo.EDI_BANKFILES SET FILEID = @fid WHERE ROWID = @id", conn);
+                update.Parameters.Add(new SqlParameter("@fid", SqlDbType.UniqueIdentifier) { Value = fileId });
+                update.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = bankFileRowId });
+                update.ExecuteNonQuery();
+            }
+        }
     }
 
     public void UpdateBankFileInfo(int rowId, string fileType, int transactionCount, decimal total)

--- a/EFT-Collections/EFTCollections.csproj
+++ b/EFT-Collections/EFTCollections.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\tmp\PAMC.DatabaseConnection\PAMC.DatabaseConnection.csproj" />
     <ProjectReference Include="..\EFTModelsIndentidier\EFTModelsIndentidier.csproj" />
+    <ProjectReference Include="..\tmp\CPS.FileStorage\CPS.FileStorage.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFT-Collections/EFTImportService.cs
+++ b/EFT-Collections/EFTImportService.cs
@@ -73,6 +73,12 @@ namespace EFT_Collections
                     break;
             }
 
+            var bankFileId = db.GetBankFileRowId(Path.GetFileName(filePath));
+            if (bankFileId > 0)
+            {
+                db.LinkFileToBankFile(bankFileId, filePath);
+            }
+
             return new EftParseResult(records, fileType, inserted);
         }
 

--- a/EFT-Collections/EFTService.cs
+++ b/EFT-Collections/EFTService.cs
@@ -355,6 +355,7 @@ public class EFTService
         int inserted = 0;
         if (!isTest)
         {
+            db.LinkFileToBankFile(recordId, Path.Combine(outputPath, fileName));
             inserted = db.InsertCollectionRequests(collections, recordId);
             db.InsertAcceptedResponses(collections, recordId);
             db.UpdateBankFileDailyCounterEnd(recordId, (int)lastSequenceNumber);

--- a/tmp/CPS.FileStorage/Utils.cs
+++ b/tmp/CPS.FileStorage/Utils.cs
@@ -53,6 +53,28 @@ namespace CPS.FileStorage
             }
         }
 
+        /// <summary>
+        /// Saves the specified file to the CPS_FILES table and returns its identifier.
+        /// </summary>
+        public static Guid SaveFile(string filePath, string connectionString)
+        {
+            byte[] data = File.ReadAllBytes(filePath);
+            Guid fileId = Guid.NewGuid();
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                using (var cmd = new SqlCommand(@"INSERT INTO CPS_FILES (ID, FILENAME, DOCBINARY, CREATEBY, CREATEDATE, LASTCHANGEDBY, LASTCHANGEDATE)
+                                             VALUES (@ID, @FILENAME, @DOCBINARY, 1, GETDATE(), 1, GETDATE())", conn))
+                {
+                    cmd.Parameters.AddWithValue("@ID", fileId);
+                    cmd.Parameters.AddWithValue("@FILENAME", Path.GetFileName(filePath));
+                    cmd.Parameters.AddWithValue("@DOCBINARY", data);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+            return fileId;
+        }
+
         public static List<DocumentFile> RetrieveDocumentsFromDb(string subssn, string connectionString)
         {
             var documents = new List<DocumentFile>();


### PR DESCRIPTION
## Summary
- add CPS.FileStorage utility to write files into CPS_FILES table
- track stored file IDs on EDI_BANKFILES entries
- link bank file records to stored files during import and generation

## Testing
- `dotnet build EFT-Collections/EFTCollections.csproj`
- `dotnet build DCCollectionsRequest/DCCollections.csproj`


------
https://chatgpt.com/codex/tasks/task_b_6890861ac6f083289cf93ad0096e0a51