### PR TITLE
feat: display bank file overview

### DIFF
--- a/DCCollectionsRequest/DatabaseService.cs
+++ b/DCCollectionsRequest/DatabaseService.cs
@@ -694,4 +694,18 @@ END", conn);
 
         return inserted;
     }
+
+    /// <summary>
+    /// Retrieves EDI bank file records.
+    /// </summary>
+    /// <returns>A table of EDI bank files.</returns>
+    public DataTable GetEdiBankFiles()
+    {
+        using var conn = new SqlConnection(_connectionString);
+        using var cmd = new SqlCommand("SELECT FileID, GenerationNumber, FileName FROM dbo.EDI_BANKFILES", conn);
+        using var adapter = new SqlDataAdapter(cmd);
+        var table = new DataTable();
+        adapter.Fill(table);
+        return table;
+    }
 }


### PR DESCRIPTION
## Summary
- show EDI bank files in new tab
- highlight files missing FileID in orange and duplicate generation numbers in light red
- provide database retrieval for bank files

## Testing
- `dotnet build DCCollections.Gui/Main.Gui.csproj` *(fails: EnableWindowsTargeting required for referenced project)*
- `dotnet build DCCollectionsRequest/DCCollections.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68908b28ec388328ab834e0bb045372a