### PR TITLE
Add Windows authentication option to login form

### DIFF
--- a/tmp/PAMC.LoginGui/LoginForm.Designer.cs
+++ b/tmp/PAMC.LoginGui/LoginForm.Designer.cs
@@ -34,12 +34,10 @@
             this.txtUsername = new System.Windows.Forms.TextBox();
             this.labelPassword = new System.Windows.Forms.Label();
             this.txtPassword = new System.Windows.Forms.TextBox();
+            this.chkWindowsAuth = new System.Windows.Forms.CheckBox();
             this.btnLogin = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.SuspendLayout();
-            // 
-            // labelServer
-            // 
             this.labelServer.AutoSize = true;
             this.labelServer.BackColor = System.Drawing.Color.Transparent;
             this.labelServer.Location = new System.Drawing.Point(262, 115);
@@ -47,17 +45,11 @@
             this.labelServer.Size = new System.Drawing.Size(41, 13);
             this.labelServer.TabIndex = 0;
             this.labelServer.Text = "Server:";
-            // 
-            // txtServer
-            // 
             this.txtServer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtServer.Location = new System.Drawing.Point(309, 111);
             this.txtServer.Name = "txtServer";
             this.txtServer.Size = new System.Drawing.Size(156, 20);
             this.txtServer.TabIndex = 1;
-            // 
-            // labelDatabase
-            // 
             this.labelDatabase.AutoSize = true;
             this.labelDatabase.BackColor = System.Drawing.Color.Transparent;
             this.labelDatabase.Location = new System.Drawing.Point(247, 135);
@@ -65,17 +57,11 @@
             this.labelDatabase.Size = new System.Drawing.Size(56, 13);
             this.labelDatabase.TabIndex = 2;
             this.labelDatabase.Text = "Database:";
-            // 
-            // txtDatabase
-            // 
             this.txtDatabase.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtDatabase.Location = new System.Drawing.Point(309, 131);
             this.txtDatabase.Name = "txtDatabase";
             this.txtDatabase.Size = new System.Drawing.Size(156, 20);
             this.txtDatabase.TabIndex = 3;
-            // 
-            // labelUsername
-            // 
             this.labelUsername.AutoSize = true;
             this.labelUsername.BackColor = System.Drawing.Color.Transparent;
             this.labelUsername.Location = new System.Drawing.Point(245, 155);
@@ -83,17 +69,11 @@
             this.labelUsername.Size = new System.Drawing.Size(58, 13);
             this.labelUsername.TabIndex = 4;
             this.labelUsername.Text = "Username:";
-            // 
-            // txtUsername
-            // 
             this.txtUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtUsername.Location = new System.Drawing.Point(309, 151);
             this.txtUsername.Name = "txtUsername";
             this.txtUsername.Size = new System.Drawing.Size(156, 20);
             this.txtUsername.TabIndex = 5;
-            // 
-            // labelPassword
-            // 
             this.labelPassword.AutoSize = true;
             this.labelPassword.BackColor = System.Drawing.Color.Transparent;
             this.labelPassword.Location = new System.Drawing.Point(247, 175);
@@ -101,45 +81,43 @@
             this.labelPassword.Size = new System.Drawing.Size(56, 13);
             this.labelPassword.TabIndex = 6;
             this.labelPassword.Text = "Password:";
-            // 
-            // txtPassword
-            // 
             this.txtPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtPassword.Location = new System.Drawing.Point(309, 171);
             this.txtPassword.Name = "txtPassword";
             this.txtPassword.PasswordChar = '*';
             this.txtPassword.Size = new System.Drawing.Size(156, 20);
             this.txtPassword.TabIndex = 7;
-            // 
-            // btnLogin
-            // 
+            this.chkWindowsAuth.AutoSize = true;
+            this.chkWindowsAuth.BackColor = System.Drawing.Color.Transparent;
+            this.chkWindowsAuth.Location = new System.Drawing.Point(309, 194);
+            this.chkWindowsAuth.Name = "chkWindowsAuth";
+            this.chkWindowsAuth.Size = new System.Drawing.Size(128, 17);
+            this.chkWindowsAuth.TabIndex = 8;
+            this.chkWindowsAuth.Text = "Windows Authentication";
+            this.chkWindowsAuth.UseVisualStyleBackColor = false;
+            this.chkWindowsAuth.CheckedChanged += new System.EventHandler(this.chkWindowsAuth_CheckedChanged);
             this.btnLogin.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnLogin.Location = new System.Drawing.Point(390, 194);
+            this.btnLogin.Location = new System.Drawing.Point(390, 214);
             this.btnLogin.Name = "btnLogin";
             this.btnLogin.Size = new System.Drawing.Size(75, 23);
-            this.btnLogin.TabIndex = 8;
+            this.btnLogin.TabIndex = 9;
             this.btnLogin.Text = "&Login";
             this.btnLogin.UseVisualStyleBackColor = true;
             this.btnLogin.Click += new System.EventHandler(this.btnLogin_Click);
-            // 
-            // btnCancel
-            // 
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(309, 194);
+            this.btnCancel.Location = new System.Drawing.Point(309, 214);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
-            this.btnCancel.TabIndex = 9;
+            this.btnCancel.TabIndex = 10;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
-            // LoginForm
-            // 
             this.AcceptButton = this.btnLogin;
             this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.ClientSize = new System.Drawing.Size(978, 529);
             this.ControlBox = false;
+            this.Controls.Add(this.chkWindowsAuth);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnLogin);
             this.Controls.Add(this.txtPassword);
@@ -172,6 +150,7 @@
         private System.Windows.Forms.TextBox txtUsername;
         private System.Windows.Forms.Label labelPassword;
         private System.Windows.Forms.TextBox txtPassword;
+        private System.Windows.Forms.CheckBox chkWindowsAuth;
         private System.Windows.Forms.Button btnLogin;
         private System.Windows.Forms.Button btnCancel;
     }


### PR DESCRIPTION
## Summary
- add Windows Authentication checkbox to login form
- handle integrated security during login

## Testing
- `dotnet build tmp/PAMC.LoginGui/PAMC.LoginGui.csproj` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_b_6891ab1241508328813a6c2140919129